### PR TITLE
add the ability to interrupt coroutines

### DIFF
--- a/context_volatile.go
+++ b/context_volatile.go
@@ -2,17 +2,29 @@
 
 package coroutine
 
+import (
+	"runtime"
+)
+
 type Context[R, S any] struct {
 	recv R
 	send S
 	next chan struct{}
+	stop bool
+	done bool
 }
 
 func (c *Context[R, S]) Yield(v R) S {
+	if c.stop {
+		panic("cannot yield from a coroutine that has been stopped")
+	}
 	var zero S
 	c.send = zero
 	c.recv = v
 	c.next <- struct{}{}
 	<-c.next
+	if c.stop {
+		runtime.Goexit()
+	}
 	return c.send
 }

--- a/coroc/coroc_test.go
+++ b/coroc/coroc_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stealthrocket/coroutine"
 	"github.com/stealthrocket/coroutine/coroc/testdata"
 )
 
-func TestCoroutine(t *testing.T) {
+func TestCoroutineYield(t *testing.T) {
 	for _, test := range []struct {
 		name   string
 		coro   func(int)
@@ -53,5 +54,25 @@ func TestCoroutine(t *testing.T) {
 				t.Errorf("coroutine did not yield the correct number of times: got %d, expect %d", yield, len(test.yields))
 			}
 		})
+	}
+}
+
+func TestCoroutineStop(t *testing.T) {
+	coro := coroutine.New[int, any](func() {
+		testdata.SquareGenerator(4)
+	})
+
+	values := []int{}
+	coroutine.Run(coro, func(v int) any {
+		if v > 10 {
+			coro.Stop()
+		} else {
+			values = append(values, v)
+		}
+		return nil
+	})
+
+	if !slices.Equal(values, []int{1, 4, 9}) {
+		t.Errorf("wrong values yield by coroutine: %#v", values)
 	}
 }

--- a/coroutine.go
+++ b/coroutine.go
@@ -3,6 +3,15 @@ package coroutine
 // Run executes a coroutine to completion, calling f for each value that the
 // coroutine yields, and sending back each value that f returns.
 func Run[R, S any](c Coroutine[R, S], f func(R) S) {
+	// The coroutine is run to completion, but f might panic in which case we
+	// don't want to leave it in an uncompleted state and interrupt it instead.
+	defer func() {
+		if !c.Done() {
+			c.Stop()
+			c.Next()
+		}
+	}()
+
 	for c.Next() {
 		r := c.Recv()
 		s := f(r)
@@ -24,9 +33,12 @@ func Yield[R, S any](v R) S {
 // The function panics when called on a stack where no active coroutine exists,
 // or if the type parameters do not match those of the coroutine.
 func LoadContext[R, S any]() *Context[R, S] {
-	if c := loadContext(getg()); c != nil {
-		return c.(*Context[R, S])
-	} else {
+	switch c := loadContext(getg()).(type) {
+	case *Context[R, S]:
+		return c
+	case nil:
 		panic("coroutine.Yield: not called from a coroutine stack")
+	default:
+		panic("coroutine.Yield: coroutine type mismatch")
 	}
 }


### PR DESCRIPTION
This PR adds the ability to interrupt coroutines by exposing two new methods: `Done` to determine whether a goroutine has completed, and `Stop` to interrupt it.

When interrupted, a coroutine does not return from its last yield point, and instead unwinds its call stack, calling each defer on the way until it terminates execution.
