### PR TITLE
add coroutine.Closure interface to represent entry points of coroutines

### DIFF
--- a/context_durable.go
+++ b/context_durable.go
@@ -20,7 +20,7 @@ type Context[R, S any] struct {
 	// Entry point of the coroutine, this is captured so the associated
 	// generator can call into the coroutine to start or resume it at the
 	// last yield point.
-	Func func()
+	Entrypoint Closure
 
 	Stack
 	Heap

--- a/coroc/coroc_durable_test.go
+++ b/coroc/coroc_durable_test.go
@@ -20,13 +20,13 @@ func assertSerializable[R, S any](t *testing.T, g coroutine.Coroutine[R, S]) cor
 	} else if n != len(b) {
 		t.Fatal("invalid number of bytes read when reconstructing context")
 	}
-	f := c.Func
+	e := c.Entrypoint
 	*c = reconstructed
 	// TODO: the context reconstruction needs to capture the
 	// coroutine entry point.
 	//
 	// https://www.notion.so/stealthrocket/Durable-Coroutines-1487e78403804b5f871cf37275a55cc8?pvs=4#395d316dc79e432ca58dd59df9f561f0
-	c.Func = f
+	c.Entrypoint = e
 
 	return g
 }

--- a/coroc/coroc_test.go
+++ b/coroc/coroc_test.go
@@ -8,75 +8,114 @@ import (
 	. "github.com/stealthrocket/coroutine/coroc/testdata"
 )
 
+type identity struct{ arg int }
+
+func (c identity) Call() { Identity(c.arg) }
+
+type squareGenerator struct{ arg int }
+
+func (c squareGenerator) Call() { SquareGenerator(c.arg) }
+
+type squareGeneratorTwice struct{ arg int }
+
+func (c squareGeneratorTwice) Call() { SquareGeneratorTwice(c.arg) }
+
+type evenSquareGenerator struct{ arg int }
+
+func (c evenSquareGenerator) Call() { EvenSquareGenerator(c.arg) }
+
+type nestedLoops struct{ arg int }
+
+func (c nestedLoops) Call() { NestedLoops(c.arg) }
+
+type fizzBuzzIfGenerator struct{ arg int }
+
+func (c fizzBuzzIfGenerator) Call() { FizzBuzzIfGenerator(c.arg) }
+
+type fizzBuzzSwitchGenerator struct{ arg int }
+
+func (c fizzBuzzSwitchGenerator) Call() { FizzBuzzSwitchGenerator(c.arg) }
+
+type shadowing struct{ arg int }
+
+func (c shadowing) Call() { Shadowing(c.arg) }
+
+type rangeSliceIndexGenerator struct{ arg int }
+
+func (c rangeSliceIndexGenerator) Call() { RangeSliceIndexGenerator(c.arg) }
+
+type rangeArrayIndexValueGenerator struct{ arg int }
+
+func (c rangeArrayIndexValueGenerator) Call() { RangeArrayIndexValueGenerator(c.arg) }
+
 func TestCoroutineYield(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		coro   func(int)
-		arg    int
+		coro   coroutine.Closure
 		yields []int
 	}{
 		{
 			name:   "identity",
-			coro:   Identity,
-			arg:    11,
+			coro:   identity{arg: 11},
 			yields: []int{11},
 		},
+
 		{
 			name:   "square generator",
-			coro:   SquareGenerator,
-			arg:    4,
+			coro:   squareGenerator{arg: 4},
 			yields: []int{1, 4, 9, 16},
 		},
+
 		{
 			name:   "square generator twice",
-			coro:   SquareGeneratorTwice,
-			arg:    4,
+			coro:   squareGeneratorTwice{arg: 4},
 			yields: []int{1, 4, 9, 16, 1, 4, 9, 16},
 		},
+
 		{
 			name:   "even square generator",
-			coro:   EvenSquareGenerator,
-			arg:    6,
+			coro:   evenSquareGenerator{arg: 6},
 			yields: []int{4, 16, 36},
 		},
+
 		{
 			name:   "nested loops",
-			coro:   NestedLoops,
-			arg:    3,
+			coro:   nestedLoops{arg: 3},
 			yields: []int{1, 2, 3, 2, 4, 6, 3, 6, 9, 2, 4, 6, 4, 8, 12, 6, 12, 18, 3, 6, 9, 6, 12, 18, 9, 18, 27},
 		},
+
 		{
 			name:   "fizz buzz (1)",
-			coro:   FizzBuzzIfGenerator,
-			arg:    20,
+			coro:   fizzBuzzIfGenerator{arg: 20},
 			yields: []int{1, 2, Fizz, 4, Buzz, Fizz, 7, 8, Fizz, Buzz, 11, Fizz, 13, 14, FizzBuzz, 16, 17, Fizz, 19, Buzz},
 		},
+
 		{
 			name:   "fizz buzz (2)",
-			coro:   FizzBuzzSwitchGenerator,
-			arg:    20,
+			coro:   fizzBuzzSwitchGenerator{arg: 20},
 			yields: []int{1, 2, Fizz, 4, Buzz, Fizz, 7, 8, Fizz, Buzz, 11, Fizz, 13, 14, FizzBuzz, 16, 17, Fizz, 19, Buzz},
 		},
+
 		{
 			name:   "shadowing",
-			coro:   Shadowing,
+			coro:   shadowing{arg: 0},
 			yields: []int{0, 1, 0, 1, 2, 0, 2, 1, 0, 2, 1, 0, 1, 0, 13, 12, 11, 4, 2, 1, 2, 1},
 		},
+
 		{
 			name:   "range over slice indices",
-			coro:   RangeSliceIndexGenerator,
+			coro:   rangeSliceIndexGenerator{arg: 0},
 			yields: []int{0, 1, 2},
 		},
+
 		{
 			name:   "range over array indices and values",
-			coro:   RangeArrayIndexValueGenerator,
+			coro:   rangeArrayIndexValueGenerator{arg: 0},
 			yields: []int{0, 10, 1, 20, 2, 30},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			g := coroutine.New[int, any](func() {
-				test.coro(test.arg)
-			})
+			g := coroutine.New[int, any](test.coro)
 
 			var yield int
 			for g.Next() {
@@ -103,9 +142,7 @@ func TestCoroutineYield(t *testing.T) {
 }
 
 func TestCoroutineStop(t *testing.T) {
-	coro := coroutine.New[int, any](func() {
-		SquareGenerator(4)
-	})
+	coro := coroutine.New[int, any](squareGenerator{arg: 4})
 
 	values := []int{}
 	coroutine.Run(coro, func(v int) any {

--- a/coroutine.go
+++ b/coroutine.go
@@ -1,5 +1,16 @@
 package coroutine
 
+// Closure is an interface implemented by types which can be used as entry
+// points to coroutines.
+//
+// Closure values are used as entry point when constructing coroutines, and
+// therefore must be serializable when building the package in durable mode.
+//
+// Because Closure values must be serializable, they cannot be functions.
+type Closure interface {
+	Call()
+}
+
 // Run executes a coroutine to completion, calling f for each value that the
 // coroutine yields, and sending back each value that f returns.
 func Run[R, S any](c Coroutine[R, S], f func(R) S) {

--- a/coroutine_durable.go
+++ b/coroutine_durable.go
@@ -35,10 +35,10 @@ func (c Coroutine[R, S]) Next() (hasNext bool) {
 	}()
 
 	c.ctx.Stack.FP = -1
-	c.ctx.Func()
+	c.ctx.Entrypoint.Call()
 	return false
 }
 
-func New[R, S any](f func()) Coroutine[R, S] {
-	return Coroutine[R, S]{ctx: &Context[R, S]{Func: f}}
+func New[R, S any](entrypoint Closure) Coroutine[R, S] {
+	return Coroutine[R, S]{ctx: &Context[R, S]{Entrypoint: entrypoint}}
 }

--- a/coroutine_volatile.go
+++ b/coroutine_volatile.go
@@ -50,8 +50,8 @@ func (c Coroutine[R, S]) Next() bool {
 	return ok
 }
 
-// New creates a new coroutine which executes f.
-func New[R, S any](f func()) Coroutine[R, S] {
+// New creates a new coroutine which executes the closure passed as entry point.
+func New[R, S any](entrypoint Closure) Coroutine[R, S] {
 	c := &Context[R, S]{
 		next: make(chan struct{}),
 	}
@@ -69,7 +69,7 @@ func New[R, S any](f func()) Coroutine[R, S] {
 		<-c.next
 
 		if !c.stop {
-			f()
+			entrypoint.Call()
 		}
 	}()
 


### PR DESCRIPTION
As discussed online, we won't be serializing Go closures so we make it more explicit that this use case isn't supported by changing the signature of `coroutine.New`.