### PR TITLE
serde: fix interface with type but nil ptr

### DIFF
--- a/serde.go
+++ b/serde.go
@@ -588,9 +588,7 @@ func deserializeStruct(d *deserializer, t reflect.Type, p unsafe.Pointer, b []by
 func serializeInterface(s *serializer, t reflect.Type, p unsafe.Pointer, b []byte) []byte {
 	i := (*iface)(p)
 
-	// TODO: there's probably a bug here for an interface with a type
-	// pointer but a nil data pointer.
-	if i.typ == nil || i.ptr == nil {
+	if i.typ == nil {
 		return serializeType(nil, b)
 	}
 

--- a/serde_test.go
+++ b/serde_test.go
@@ -46,6 +46,8 @@ func TestReflect(t *testing.T) {
 			[]interface{}{nil, 42, nil},
 			struct{ a *int }{intp},
 			[1][2]int{{1, 2}},
+
+			[]interface{}{(*int)(nil)},
 		}
 
 		for _, x := range cases {


### PR DESCRIPTION
If an interface contains a nil pointer but a non-nil type, the latter still needs to be serialized for the value to be reconstructed exactly.