### PR TITLE
Labeled break/continue support

### DIFF
--- a/coroc/compiler/unsupported.go
+++ b/coroc/compiler/unsupported.go
@@ -23,8 +23,6 @@ func unsupported(decl *ast.FuncDecl, info *types.Info) (err error) {
 				err = fmt.Errorf("not implemented: defer")
 			case *ast.GoStmt:
 				err = fmt.Errorf("not implemented: go")
-			case *ast.LabeledStmt:
-				err = fmt.Errorf("not implemented: labels")
 			case *ast.SelectStmt:
 				err = fmt.Errorf("not implemented: select")
 			case *ast.CommClause:
@@ -42,8 +40,12 @@ func unsupported(decl *ast.FuncDecl, info *types.Info) (err error) {
 					err = fmt.Errorf("not implemented: goto")
 				} else if n.Tok == token.FALLTHROUGH {
 					err = fmt.Errorf("not implemented: fallthrough")
-				} else if n.Label != nil {
-					err = fmt.Errorf("not implemented: labeled break/continue")
+				}
+			case *ast.LabeledStmt:
+				switch n.Stmt.(type) {
+				case *ast.ForStmt, *ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt:
+				default:
+					err = fmt.Errorf("not implemented: labels not attached to for/switch/select")
 				}
 			case *ast.ForStmt:
 				// Since we aren't desugaring for loop post iteration

--- a/coroc/coroc_test.go
+++ b/coroc/coroc_test.go
@@ -131,7 +131,7 @@ func TestCoroutineYield(t *testing.T) {
 		{
 			name:   "loop break and continue",
 			coro:   loopBreakAndContinue{},
-			yields: []int{1, 3, 5},
+			yields: []int{1, 3, 5, 0, 1, 0, 1},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/coroc/testdata/coroutine.go
+++ b/coroc/testdata/coroutine.go
@@ -191,4 +191,22 @@ func LoopBreakAndContinue(_ int) {
 		}
 		coroutine.Yield[int, any](i)
 	}
+
+outer:
+	for i := 0; i < 2; i++ {
+		for j := 0; j < 3; j++ {
+			coroutine.Yield[int, any](j)
+			switch j {
+			case 0:
+				continue
+			case 1:
+				switch i {
+				case 0:
+					continue outer
+				case 1:
+					break outer
+				}
+			}
+		}
+	}
 }

--- a/coroc/testdata/coroutine_durable.go
+++ b/coroc/testdata/coroutine_durable.go
@@ -684,49 +684,101 @@ func LoopBreakAndContinue(_ int) {
 	_f := _c.Push()
 	var _o0 int
 	var _o1 int
+	var _o2 int
+	var _o3 int
 	if _f.IP > 0 {
 		_o0 = _f.Get(0).(int)
 		_o1 = _f.Get(1).(int)
+
+		_o2 = _f.Get(2).(int)
+		_o3 = _f.Get(3).(int)
 	}
 	defer func() {
 		if _c.Unwinding() {
 			_f.Set(0, _o0)
 			_f.Set(1, _o1)
+			_f.Set(2, _o2)
+			_f.Set(3, _o3)
 		} else {
 			_c.Pop()
 		}
 	}()
 	switch {
-	case _f.IP < 2:
-		_o0 = 0
-		_f.IP = 2
-		fallthrough
 	case _f.IP < 6:
-	_l0:
-		for ; _o0 < 10; _o0, _f.IP = _o0+1, 2 {
-			switch {
-			case _f.IP < 4:
+		switch {
+		case _f.IP < 2:
+			_o0 = 0
+			_f.IP = 2
+			fallthrough
+		case _f.IP < 6:
+		_l0:
+			for ; _o0 < 10; _o0, _f.IP = _o0+1, 2 {
 				switch {
-				case _f.IP < 3:
-					_o1 = _o0 % 2
-					_f.IP = 3
-					fallthrough
 				case _f.IP < 4:
-					if _o1 == 0 {
-						continue _l0
+					switch {
+					case _f.IP < 3:
+						_o1 = _o0 % 2
+						_f.IP = 3
+						fallthrough
+					case _f.IP < 4:
+						if _o1 == 0 {
+							continue _l0
+						}
+					}
+					_f.IP = 4
+					fallthrough
+				case _f.IP < 5:
+					if _o0 > 5 {
+						break _l0
+					}
+					_f.IP = 5
+					fallthrough
+				case _f.IP < 6:
+
+					coroutine.Yield[int, any](_o0)
+				}
+			}
+		}
+		_f.IP = 6
+		fallthrough
+	case _f.IP < 12:
+		switch {
+		case _f.IP < 7:
+
+			_o2 = 0
+			_f.IP = 7
+			fallthrough
+		case _f.IP < 12:
+		_l1:
+			for ; _o2 < 2; _o2, _f.IP = _o2+1, 7 {
+				switch {
+				case _f.IP < 8:
+					_o3 = 0
+					_f.IP = 8
+					fallthrough
+				case _f.IP < 12:
+				_l2:
+					for ; _o3 < 3; _o3, _f.IP = _o3+1, 8 {
+						switch {
+						case _f.IP < 9:
+							coroutine.Yield[int, any](_o3)
+							_f.IP = 9
+							fallthrough
+						case _f.IP < 12:
+							switch _o3 {
+							case 0:
+								continue _l2
+							case 1:
+								switch _o2 {
+								case 0:
+									continue _l1
+								case 1:
+									break _l1
+								}
+							}
+						}
 					}
 				}
-				_f.IP = 4
-				fallthrough
-			case _f.IP < 5:
-				if _o0 > 5 {
-					break _l0
-				}
-				_f.IP = 5
-				fallthrough
-			case _f.IP < 6:
-
-				coroutine.Yield[int, any](_o0)
 			}
 		}
 	}


### PR DESCRIPTION
Follow up to https://github.com/stealthrocket/coroutine/pull/22 that relaxes the constraint that `break` and `continue` statements were not allowed to have a label.