### PR TITLE
serializable functions

### DIFF
--- a/compiler/coroutine_durable_test.go
+++ b/compiler/coroutine_durable_test.go
@@ -20,13 +20,6 @@ func assertSerializable[R, S any](t *testing.T, g coroutine.Coroutine[R, S]) cor
 	} else if n != len(b) {
 		t.Fatal("invalid number of bytes read when reconstructing context")
 	}
-	e := c.Entrypoint
 	*c = reconstructed
-	// TODO: the context reconstruction needs to capture the
-	// coroutine entry point.
-	//
-	// https://www.notion.so/stealthrocket/Durable-Coroutines-1487e78403804b5f871cf37275a55cc8?pvs=4#395d316dc79e432ca58dd59df9f561f0
-	c.Entrypoint = e
-
 	return g
 }

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -1,149 +1,111 @@
 package compiler
 
 import (
+	"reflect"
 	"slices"
 	"testing"
 
 	"github.com/stealthrocket/coroutine"
 	. "github.com/stealthrocket/coroutine/compiler/testdata"
+	"github.com/stealthrocket/coroutine/types"
 )
 
-type identity struct{ arg int }
-
-func (c identity) Call() { Identity(c.arg) }
-
-type squareGenerator struct{ arg int }
-
-func (c squareGenerator) Call() { SquareGenerator(c.arg) }
-
-type squareGeneratorTwice struct{ arg int }
-
-func (c squareGeneratorTwice) Call() { SquareGeneratorTwice(c.arg) }
-
-type evenSquareGenerator struct{ arg int }
-
-func (c evenSquareGenerator) Call() { EvenSquareGenerator(c.arg) }
-
-type nestedLoops struct{ arg int }
-
-func (c nestedLoops) Call() { NestedLoops(c.arg) }
-
-type fizzBuzzIfGenerator struct{ arg int }
-
-func (c fizzBuzzIfGenerator) Call() { FizzBuzzIfGenerator(c.arg) }
-
-type fizzBuzzSwitchGenerator struct{ arg int }
-
-func (c fizzBuzzSwitchGenerator) Call() { FizzBuzzSwitchGenerator(c.arg) }
-
-type shadowing struct{ arg int }
-
-func (c shadowing) Call() { Shadowing(c.arg) }
-
-type rangeSliceIndexGenerator struct{ arg int }
-
-func (c rangeSliceIndexGenerator) Call() { RangeSliceIndexGenerator(c.arg) }
-
-type rangeArrayIndexValueGenerator struct{ arg int }
-
-func (c rangeArrayIndexValueGenerator) Call() { RangeArrayIndexValueGenerator(c.arg) }
-
-type typeSwitchingGenerator struct{ arg int }
-
-func (c typeSwitchingGenerator) Call() { TypeSwitchingGenerator(c.arg) }
-
-type loopBreakAndContinue struct{ arg int }
-
-func (c loopBreakAndContinue) Call() { LoopBreakAndContinue(c.arg) }
-
-type rangeOverMaps struct{ arg int }
-
-func (c rangeOverMaps) Call() { RangeOverMaps(c.arg) }
-
 func TestCoroutineYield(t *testing.T) {
-	for _, test := range []struct {
+	tests := []struct {
 		name   string
-		coro   coroutine.Closure
+		coro   func()
 		yields []int
 	}{
 		{
 			name:   "identity",
-			coro:   identity{arg: 11},
+			coro:   func() { Identity(11) },
 			yields: []int{11},
 		},
 
 		{
 			name:   "square generator",
-			coro:   squareGenerator{arg: 4},
+			coro:   func() { SquareGenerator(4) },
 			yields: []int{1, 4, 9, 16},
 		},
 
 		{
 			name:   "square generator twice",
-			coro:   squareGeneratorTwice{arg: 4},
+			coro:   func() { SquareGeneratorTwice(4) },
 			yields: []int{1, 4, 9, 16, 1, 4, 9, 16},
 		},
 
 		{
 			name:   "even square generator",
-			coro:   evenSquareGenerator{arg: 6},
+			coro:   func() { EvenSquareGenerator(6) },
 			yields: []int{4, 16, 36},
 		},
 
 		{
 			name:   "nested loops",
-			coro:   nestedLoops{arg: 3},
+			coro:   func() { NestedLoops(3) },
 			yields: []int{1, 2, 3, 2, 4, 6, 3, 6, 9, 2, 4, 6, 4, 8, 12, 6, 12, 18, 3, 6, 9, 6, 12, 18, 9, 18, 27},
 		},
 
 		{
 			name:   "fizz buzz (1)",
-			coro:   fizzBuzzIfGenerator{arg: 20},
+			coro:   func() { FizzBuzzIfGenerator(20) },
 			yields: []int{1, 2, Fizz, 4, Buzz, Fizz, 7, 8, Fizz, Buzz, 11, Fizz, 13, 14, FizzBuzz, 16, 17, Fizz, 19, Buzz},
 		},
 
 		{
 			name:   "fizz buzz (2)",
-			coro:   fizzBuzzSwitchGenerator{arg: 20},
+			coro:   func() { FizzBuzzSwitchGenerator(20) },
 			yields: []int{1, 2, Fizz, 4, Buzz, Fizz, 7, 8, Fizz, Buzz, 11, Fizz, 13, 14, FizzBuzz, 16, 17, Fizz, 19, Buzz},
 		},
 
 		{
 			name:   "shadowing",
-			coro:   shadowing{arg: 0},
+			coro:   func() { Shadowing(0) },
 			yields: []int{0, 1, 0, 1, 2, 0, 2, 1, 0, 2, 1, 0, 1, 0, 13, 12, 11, 4, 2, 1, 2, 1},
 		},
 
 		{
 			name:   "range over slice indices",
-			coro:   rangeSliceIndexGenerator{arg: 0},
+			coro:   func() { RangeSliceIndexGenerator(0) },
 			yields: []int{0, 1, 2},
 		},
 
 		{
 			name:   "range over array indices and values",
-			coro:   rangeArrayIndexValueGenerator{arg: 0},
+			coro:   func() { RangeArrayIndexValueGenerator(0) },
 			yields: []int{0, 10, 1, 20, 2, 30},
 		},
 
 		{
 			name:   "type switching",
-			coro:   typeSwitchingGenerator{},
+			coro:   func() { TypeSwitchingGenerator(0) },
 			yields: []int{1, 10, 2, 20, 4, 30, 8, 40},
 		},
 
 		{
 			name:   "loop break and continue",
-			coro:   loopBreakAndContinue{},
+			coro:   func() { LoopBreakAndContinue(0) },
 			yields: []int{1, 3, 5, 0, 1, 0, 1},
 		},
 
 		{
 			name:   "range over maps",
-			coro:   rangeOverMaps{arg: 5},
+			coro:   func() { RangeOverMaps(5) },
 			yields: []int{0, 5, 5, 50, 5, 4, 3, 2, 1, 0},
 		},
-	} {
+	}
+
+	// TODO: remove me
+	//
+	// This emulates the installation of function type information by the
+	// compiler until we have codegen for it.
+	for _, test := range tests {
+		a := types.FuncAddr(test.coro)
+		f := types.FuncByAddr(a)
+		f.Type = reflect.TypeOf(func() {})
+	}
+
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := coroutine.New[int, any](test.coro)
 
@@ -172,7 +134,7 @@ func TestCoroutineYield(t *testing.T) {
 }
 
 func TestCoroutineStop(t *testing.T) {
-	coro := coroutine.New[int, any](squareGenerator{arg: 4})
+	coro := coroutine.New[int, any](func() { SquareGenerator(4) })
 
 	values := []int{}
 	coroutine.Run(coro, func(v int) any {

--- a/coroutine.go
+++ b/coroutine.go
@@ -1,16 +1,5 @@
 package coroutine
 
-// Closure is an interface implemented by types which can be used as entry
-// points to coroutines.
-//
-// Closure values are used as entry point when constructing coroutines, and
-// therefore must be serializable when building the package in durable mode.
-//
-// Because Closure values must be serializable, they cannot be functions.
-type Closure interface {
-	Call()
-}
-
 // Run executes a coroutine to completion, calling f for each value that the
 // coroutine yields, and sending back each value that f returns.
 func Run[R, S any](c Coroutine[R, S], f func(R) S) {

--- a/coroutine_durable.go
+++ b/coroutine_durable.go
@@ -35,10 +35,10 @@ func (c Coroutine[R, S]) Next() (hasNext bool) {
 	}()
 
 	c.ctx.Stack.FP = -1
-	c.ctx.Entrypoint.Call()
+	c.ctx.entry()
 	return false
 }
 
-func New[R, S any](entrypoint Closure) Coroutine[R, S] {
-	return Coroutine[R, S]{ctx: &Context[R, S]{Entrypoint: entrypoint}}
+func New[R, S any](f func()) Coroutine[R, S] {
+	return Coroutine[R, S]{ctx: &Context[R, S]{entry: f}}
 }

--- a/coroutine_volatile.go
+++ b/coroutine_volatile.go
@@ -50,8 +50,8 @@ func (c Coroutine[R, S]) Next() bool {
 	return ok
 }
 
-// New creates a new coroutine which executes the closure passed as entry point.
-func New[R, S any](entrypoint Closure) Coroutine[R, S] {
+// New creates a new coroutine which executes f as entry point.
+func New[R, S any](f func()) Coroutine[R, S] {
 	c := &Context[R, S]{
 		next: make(chan struct{}),
 	}
@@ -69,7 +69,7 @@ func New[R, S any](entrypoint Closure) Coroutine[R, S] {
 		<-c.next
 
 		if !c.stop {
-			entrypoint.Call()
+			f()
 		}
 	}()
 

--- a/internal/serde/unsafe.go
+++ b/internal/serde/unsafe.go
@@ -22,6 +22,8 @@ type slice struct {
 // returns true iff type t would be inlined in an interface.
 func inlined(t reflect.Type) bool {
 	switch t.Kind() {
+	case reflect.Func:
+		return true
 	case reflect.Ptr:
 		return true
 	case reflect.Map:

--- a/types/func.go
+++ b/types/func.go
@@ -51,7 +51,7 @@ type Func struct {
 // access the address of the function in memory.
 type closure struct{ addr uintptr }
 
-// Address returns the address in memory of the closure passed as argument.
+// FuncAddr returns the address in memory of the closure passed as argument.
 //
 // This function can only resolve addresses of closures in the compilation unit
 // that it is part of; for example, if compiled in a Go plugin, it can only
@@ -61,7 +61,7 @@ type closure struct{ addr uintptr }
 // If the argument is a nil function value, the return address is zero.
 //
 // The function panics if called with a value which is not a function.
-func Address(fn any) uintptr {
+func FuncAddr(fn any) uintptr {
 	if reflect.TypeOf(fn).Kind() != reflect.Func {
 		panic("value must be a function")
 	}

--- a/types/func_test.go
+++ b/types/func_test.go
@@ -12,18 +12,18 @@ func TestAddressOfNonFunctionValue(t *testing.T) {
 			t.Error("taking the address of a non-function value did not panic")
 		}
 	}()
-	Address(0)
+	FuncAddr(0)
 }
 
 func TestAddressOfNilFunctionValue(t *testing.T) {
-	if addr := Address((func())(nil)); addr != 0 {
+	if addr := FuncAddr((func())(nil)); addr != 0 {
 		t.Errorf("wrong address for nil function value: want=0 got=%v", addr)
 	}
 }
 
 func TestFunctionAddress(t *testing.T) {
 	name, addr1 := sentinel()
-	addr2 := Address(sentinel)
+	addr2 := FuncAddr(sentinel)
 
 	if addr1 != addr2 {
 		t.Errorf("%s: function address mismatch: want=%#v got=%#v", name, addr1, addr2)
@@ -33,7 +33,7 @@ func TestFunctionAddress(t *testing.T) {
 func TestFunctionLookup(t *testing.T) {
 	name := "github.com/stealthrocket/coroutine/types.TestFunctionLookup"
 	sym1 := FuncByName(name)
-	sym2 := FuncByAddr(Address(TestFunctionLookup))
+	sym2 := FuncByAddr(FuncAddr(TestFunctionLookup))
 
 	if sym1 != sym2 {
 		t.Errorf("%s: symbols returned by name and address lookups mismatch: %p != %p", name, sym1, sym2)
@@ -47,7 +47,7 @@ func TestClosureAddress(t *testing.T) {
 
 	name := "github.com/stealthrocket/coroutine/types.op.func1"
 	addr1 := c.addr
-	addr2 := Address(f)
+	addr2 := FuncAddr(f)
 
 	if addr1 != addr2 {
 		t.Errorf("%s: closure address mismatch: want=%#v got=%#v", name, addr1, addr2)
@@ -59,7 +59,7 @@ func TestClosureLookup(t *testing.T) {
 
 	name := "github.com/stealthrocket/coroutine/types.op.func1"
 	sym1 := FuncByName(name)
-	sym2 := FuncByAddr(Address(f))
+	sym2 := FuncByAddr(FuncAddr(f))
 
 	if sym1 != sym2 {
 		t.Errorf("%s: symbols returned by name and address lookups mismatch: %p != %p", name, sym1, sym2)


### PR DESCRIPTION
This PR adds support for serializing functions and modifies the tests to reflect this new capability; notably, we don't need to declare intermediary struct types for each coroutine we test since we can now reconstruct the entry point.
