### PR TITLE
Use inclusive ranges for regions

### DIFF
--- a/internal/serde/scan.go
+++ b/internal/serde/scan.go
@@ -185,7 +185,7 @@ func (r *regions) extend(i int) {
 
 type region struct {
 	start unsafe.Pointer // inclusive
-	end   unsafe.Pointer // exclusive
+	end   unsafe.Pointer // inclusive
 	typ   reflect.Type
 }
 


### PR DESCRIPTION
To avoid creating a pointer just past an allocated object.