### PR TITLE
Fix inlined arrays

### DIFF
--- a/internal/serde/unsafe.go
+++ b/internal/serde/unsafe.go
@@ -30,6 +30,8 @@ func inlined(t reflect.Type) bool {
 		return true
 	case reflect.Struct:
 		return t.NumField() == 1 && inlined(t.Field(0).Type)
+	case reflect.Array:
+		return t.Len() == 1 && inlined(t.Elem())
 	default:
 		return false
 	}

--- a/serde/serde_test.go
+++ b/serde/serde_test.go
@@ -61,6 +61,8 @@ func TestReflect(t *testing.T) {
 
 			func() {},
 			func(int) int { return 42 },
+
+			[1]*int{intp},
 		}
 
 		for _, x := range cases {


### PR DESCRIPTION
Arrays of size 1 with inlined type are inlined in interfaces. This test would panic before.

https://cs.opensource.google/go/go/+/master:src/cmd/compile/internal/types/type.go;l=1824-1826;drc=cc904eb0e87a00430bec8d1918f649638553e5de