### PR TITLE
Make maps shareable

### DIFF
--- a/internal/serde/scan.go
+++ b/internal/serde/scan.go
@@ -149,6 +149,7 @@ func (c *containers) fixup(i int) {
 			c.remove(i + 1)
 			return
 		}
+		c.remove(i + 1)
 		// Array fully contains next container. Nothing to do
 		return
 	}

--- a/serde/serde_test.go
+++ b/serde/serde_test.go
@@ -241,6 +241,32 @@ func TestReflectCustom(t *testing.T) {
 }
 
 func TestReflectSharing(t *testing.T) {
+	testReflect(t, "maps of ints", func(t *testing.T) {
+		m := map[int]int{1: 2, 3: 4}
+
+		type X struct {
+			a map[int]int
+			b map[int]int
+		}
+
+		x := X{
+			a: m,
+			b: m,
+		}
+
+		// make sure map is shared beforehand
+		x.a[5] = 6
+		assertEqual(t, 6, x.b[5])
+
+		serde.RegisterType[X]()
+
+		out := assertRoundTrip(t, x)
+
+		// check map is shared after
+		out.a[7] = 8
+		assertEqual(t, 8, out.b[7])
+	})
+
 	testReflect(t, "slice backing array", func(t *testing.T) {
 		data := make([]int, 10)
 		for i := range data {


### PR DESCRIPTION
When serializing two maps that point to the same data, link them back together.