### PR TITLE
Bring static pointers back to the static table

### DIFF
--- a/internal/serde/reflect.go
+++ b/internal/serde/reflect.go
@@ -215,6 +215,13 @@ func serializePointedAt(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 		return
 	}
 
+	if static(p) {
+		serializeVarint(s, -1)
+		off := staticOffset(p)
+		serializeVarint(s, off)
+		return
+	}
+
 	id, new := s.assignPointerID(p)
 	serializeVarint(s, int(id))
 	if !new {

--- a/internal/serde/serde.go
+++ b/internal/serde/serde.go
@@ -71,6 +71,15 @@ func newDeserializer(b []byte) *Deserializer {
 func (d *Deserializer) readPtr() (unsafe.Pointer, sID) {
 	x, n := binary.Varint(d.b)
 	d.b = d.b[n:]
+
+	// pointer into static uint64 table
+	if x == -1 {
+		x, n = binary.Varint(d.b)
+		d.b = d.b[n:]
+		p := staticPointer(int(x))
+		return p, 0
+	}
+
 	i := sID(x)
 	p := d.ptrs[i]
 	return p, i

--- a/internal/serde/unsafe.go
+++ b/internal/serde/unsafe.go
@@ -36,3 +36,23 @@ func inlined(t reflect.Type) bool {
 		return false
 	}
 }
+
+var staticuint64s unsafe.Pointer
+
+func init() {
+	zero := 0
+	var x interface{} = zero
+	staticuint64s = (*iface)(unsafe.Pointer(&x)).ptr
+}
+
+func static(p unsafe.Pointer) bool {
+	return uintptr(p) >= uintptr(staticuint64s) && uintptr(p) < uintptr(staticuint64s)+256
+}
+
+func staticOffset(p unsafe.Pointer) int {
+	return int(uintptr(p) - uintptr(staticuint64s))
+}
+
+func staticPointer(offset int) unsafe.Pointer {
+	return unsafe.Add(staticuint64s, offset)
+}

--- a/serde/serde_test.go
+++ b/serde/serde_test.go
@@ -93,6 +93,16 @@ func TestReflect(t *testing.T) {
 	})
 }
 
+func TestInt257(t *testing.T) {
+	one := 1
+	x := []any{
+		true,
+		one,
+	}
+	serde.RegisterType[[]any]()
+	assertRoundTrip(t, x)
+}
+
 func TestReflectCustom(t *testing.T) {
 	ser := func(s *serde.Serializer, x *int) error {
 		str := strconv.Itoa(*x)


### PR DESCRIPTION
When serializing a pointer to the static 256 entries uint64 table, encode it as an offset into that table. Deserialize them by pointing back at the static table.

This is a band-aid to fix https://github.com/stealthrocket/coroutine/pull/44. Symptom was a `(int) 1` on the objects slice turning into `(int) 257`. I think there is a deeper problem to be solved when two pointers point to the same address but have different size, and the smaller one is encountered first. Maybe time to create that intermediate representation to figure those out :) 