### PR TITLE
compile function literals

### DIFF
--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -2156,11 +2156,27 @@ func RangeTripleFuncValue(n int) {
 	switch {
 	case _f.IP < 2:
 		_o0 = func(i int) {
+			_c := coroutine.LoadContext[int, any]()
+			_f, _fp := _c.Push()
+			if _f.IP > 0 {
+				if _v := _f.Get(0); _v != nil {
+					i = _v.(int)
+				}
+			}
+			defer func() {
+				if _c.Unwinding() {
+					_f.Set(0, i)
+					_c.Store(_fp, _f)
+				} else {
+					_c.Pop()
+				}
+			}()
 			coroutine.Yield[int, any](3 * i)
 		}
 		_f.IP = 2
 		fallthrough
 	case _f.IP < 3:
+
 		Range(n, _o0)
 	}
 }
@@ -2168,30 +2184,30 @@ func RangeTripleFuncValue(n int) {
 func Range10ClosureCapturingValues() {
 	_c := coroutine.LoadContext[int, any]()
 	_f, _fp := _c.Push()
-	var _o0 int
 	var _o1 int
-	var _o2 func() bool
-	var _o3 bool
+	var _o2 int
+	var _o3 func() bool
+	var _o4 bool
 	if _f.IP > 0 {
 		if _v := _f.Get(0); _v != nil {
-			_o0 = _v.(int)
-		}
-		if _v := _f.Get(1); _v != nil {
 			_o1 = _v.(int)
 		}
+		if _v := _f.Get(1); _v != nil {
+			_o2 = _v.(int)
+		}
 		if _v := _f.Get(2); _v != nil {
-			_o2 = _v.(func() bool)
+			_o3 = _v.(func() bool)
 		}
 		if _v := _f.Get(3); _v != nil {
-			_o3 = _v.(bool)
+			_o4 = _v.(bool)
 		}
 	}
 	defer func() {
 		if _c.Unwinding() {
-			_f.Set(0, _o0)
-			_f.Set(1, _o1)
-			_f.Set(2, _o2)
-			_f.Set(3, _o3)
+			_f.Set(0, _o1)
+			_f.Set(1, _o2)
+			_f.Set(2, _o3)
+			_f.Set(3, _o4)
 			_c.Store(_fp, _f)
 		} else {
 			_c.Pop()
@@ -2199,21 +2215,61 @@ func Range10ClosureCapturingValues() {
 	}()
 	switch {
 	case _f.IP < 2:
-		_o0 = 0
+		_o1 = 0
 		_f.IP = 2
 		fallthrough
 	case _f.IP < 3:
-		_o1 = 10
+		_o2 = 10
 		_f.IP = 3
 		fallthrough
 	case _f.IP < 4:
-		_o2 = func() bool {
-			if _o0 < _o1 {
-				coroutine.Yield[int, any](_o0)
-				_o0++
-				return true
+		_o3 = func() (_ bool) {
+			_c := coroutine.LoadContext[int, any]()
+			_f, _fp := _c.Push()
+			var _o0 bool
+			if _f.IP > 0 {
+				if _v := _f.Get(0); _v != nil {
+					_o0 = _v.(bool)
+				}
 			}
-			return false
+			defer func() {
+				if _c.Unwinding() {
+					_f.Set(0, _o0)
+					_c.Store(_fp, _f)
+				} else {
+					_c.Pop()
+				}
+			}()
+			switch {
+			case _f.IP < 5:
+				switch {
+				case _f.IP < 2:
+					_o0 = _o1 < _o2
+					_f.IP = 2
+					fallthrough
+				case _f.IP < 5:
+					if _o0 {
+						switch {
+						case _f.IP < 3:
+							coroutine.Yield[int, any](_o1)
+							_f.IP = 3
+							fallthrough
+						case _f.IP < 4:
+							_o1++
+							_f.IP = 4
+							fallthrough
+						case _f.IP < 5:
+							return true
+						}
+					}
+				}
+				_f.IP = 5
+				fallthrough
+			case _f.IP < 6:
+
+				return false
+			}
+			return
 		}
 		_f.IP = 4
 		fallthrough
@@ -2222,11 +2278,11 @@ func Range10ClosureCapturingValues() {
 		for ; ; _f.IP = 4 {
 			switch {
 			case _f.IP < 5:
-				_o3 = !_o2()
+				_o4 = !_o3()
 				_f.IP = 5
 				fallthrough
 			case _f.IP < 6:
-				if _o3 {
+				if _o4 {
 					break _l0
 				}
 			}
@@ -2237,40 +2293,40 @@ func Range10ClosureCapturingValues() {
 func Range10ClosureCapturingPointers() {
 	_c := coroutine.LoadContext[int, any]()
 	_f, _fp := _c.Push()
-	var _o0 int
 	var _o1 int
-	var _o2 *int
+	var _o2 int
 	var _o3 *int
-	var _o4 func() bool
-	var _o5 bool
+	var _o4 *int
+	var _o5 func() bool
+	var _o6 bool
 	if _f.IP > 0 {
 		if _v := _f.Get(0); _v != nil {
-			_o0 = _v.(int)
-		}
-		if _v := _f.Get(1); _v != nil {
 			_o1 = _v.(int)
 		}
-		if _v := _f.Get(2); _v != nil {
-			_o2 = _v.(*int)
+		if _v := _f.Get(1); _v != nil {
+			_o2 = _v.(int)
 		}
-		if _v := _f.Get(3); _v != nil {
+		if _v := _f.Get(2); _v != nil {
 			_o3 = _v.(*int)
 		}
+		if _v := _f.Get(3); _v != nil {
+			_o4 = _v.(*int)
+		}
 		if _v := _f.Get(4); _v != nil {
-			_o4 = _v.(func() bool)
+			_o5 = _v.(func() bool)
 		}
 		if _v := _f.Get(5); _v != nil {
-			_o5 = _v.(bool)
+			_o6 = _v.(bool)
 		}
 	}
 	defer func() {
 		if _c.Unwinding() {
-			_f.Set(0, _o0)
-			_f.Set(1, _o1)
-			_f.Set(2, _o2)
-			_f.Set(3, _o3)
-			_f.Set(4, _o4)
-			_f.Set(5, _o5)
+			_f.Set(0, _o1)
+			_f.Set(1, _o2)
+			_f.Set(2, _o3)
+			_f.Set(3, _o4)
+			_f.Set(4, _o5)
+			_f.Set(5, _o6)
 			_c.Store(_fp, _f)
 		} else {
 			_c.Pop()
@@ -2278,25 +2334,65 @@ func Range10ClosureCapturingPointers() {
 	}()
 	switch {
 	case _f.IP < 2:
-		_o0, _o1 = 0, 10
+		_o1, _o2 = 0, 10
 		_f.IP = 2
 		fallthrough
 	case _f.IP < 3:
-		_o2 = &_o0
+		_o3 = &_o1
 		_f.IP = 3
 		fallthrough
 	case _f.IP < 4:
-		_o3 = &_o1
+		_o4 = &_o2
 		_f.IP = 4
 		fallthrough
 	case _f.IP < 5:
-		_o4 = func() bool {
-			if *_o2 < *_o3 {
-				coroutine.Yield[int, any](*_o2)
-				(*_o2)++
-				return true
+		_o5 = func() (_ bool) {
+			_c := coroutine.LoadContext[int, any]()
+			_f, _fp := _c.Push()
+			var _o0 bool
+			if _f.IP > 0 {
+				if _v := _f.Get(0); _v != nil {
+					_o0 = _v.(bool)
+				}
 			}
-			return false
+			defer func() {
+				if _c.Unwinding() {
+					_f.Set(0, _o0)
+					_c.Store(_fp, _f)
+				} else {
+					_c.Pop()
+				}
+			}()
+			switch {
+			case _f.IP < 5:
+				switch {
+				case _f.IP < 2:
+					_o0 = *_o3 < *_o4
+					_f.IP = 2
+					fallthrough
+				case _f.IP < 5:
+					if _o0 {
+						switch {
+						case _f.IP < 3:
+							coroutine.Yield[int, any](*_o3)
+							_f.IP = 3
+							fallthrough
+						case _f.IP < 4:
+							(*_o3)++
+							_f.IP = 4
+							fallthrough
+						case _f.IP < 5:
+							return true
+						}
+					}
+				}
+				_f.IP = 5
+				fallthrough
+			case _f.IP < 6:
+
+				return false
+			}
+			return
 		}
 		_f.IP = 5
 		fallthrough
@@ -2305,11 +2401,11 @@ func Range10ClosureCapturingPointers() {
 		for ; ; _f.IP = 5 {
 			switch {
 			case _f.IP < 6:
-				_o5 = !_o4()
+				_o6 = !_o5()
 				_f.IP = 6
 				fallthrough
 			case _f.IP < 7:
-				if _o5 {
+				if _o6 {
 					break _l0
 				}
 			}
@@ -2320,76 +2416,76 @@ func Range10ClosureCapturingPointers() {
 func Range10ClosureHeterogenousCapture() {
 	_c := coroutine.LoadContext[int, any]()
 	_f, _fp := _c.Push()
-	var _o0 int8
-	var _o1 int16
-	var _o2 int32
-	var _o3 int64
-	var _o4 uint8
-	var _o5 uint16
-	var _o6 uint32
-	var _o7 uint64
-	var _o8 uintptr
-	var _o9 func() int
-	var _o10 int
-	var _o11 func() bool
-	var _o12 bool
+	var _o12 int8
+	var _o13 int16
+	var _o14 int32
+	var _o15 int64
+	var _o16 uint8
+	var _o17 uint16
+	var _o18 uint32
+	var _o19 uint64
+	var _o20 uintptr
+	var _o21 func() int
+	var _o22 int
+	var _o23 func() bool
+	var _o24 bool
 	if _f.IP > 0 {
 		if _v := _f.Get(0); _v != nil {
-			_o0 = _v.(int8)
+			_o12 = _v.(int8)
 		}
 		if _v := _f.Get(1); _v != nil {
-			_o1 = _v.(int16)
+			_o13 = _v.(int16)
 		}
 		if _v := _f.Get(2); _v != nil {
-			_o2 = _v.(int32)
+			_o14 = _v.(int32)
 		}
 		if _v := _f.Get(3); _v != nil {
-			_o3 = _v.(int64)
+			_o15 = _v.(int64)
 		}
 		if _v := _f.Get(4); _v != nil {
-			_o4 = _v.(uint8)
+			_o16 = _v.(uint8)
 		}
 		if _v := _f.Get(5); _v != nil {
-			_o5 = _v.(uint16)
+			_o17 = _v.(uint16)
 		}
 		if _v := _f.Get(6); _v != nil {
-			_o6 = _v.(uint32)
+			_o18 = _v.(uint32)
 		}
 		if _v := _f.Get(7); _v != nil {
-			_o7 = _v.(uint64)
+			_o19 = _v.(uint64)
 		}
 		if _v := _f.Get(8); _v != nil {
-			_o8 = _v.(uintptr)
+			_o20 = _v.(uintptr)
 		}
 		if _v := _f.Get(9); _v != nil {
-			_o9 = _v.(func() int)
+			_o21 = _v.(func() int)
 		}
 		if _v := _f.Get(10); _v != nil {
 
-			_o10 = _v.(int)
+			_o22 = _v.(int)
 		}
 		if _v := _f.Get(11); _v != nil {
-			_o11 = _v.(func() bool)
+			_o23 = _v.(func() bool)
 		}
 		if _v := _f.Get(12); _v != nil {
-			_o12 = _v.(bool)
+			_o24 = _v.(bool)
 		}
 	}
 	defer func() {
 		if _c.Unwinding() {
-			_f.Set(0, _o0)
-			_f.Set(1, _o1)
-			_f.Set(2, _o2)
-			_f.Set(3, _o3)
-			_f.Set(4, _o4)
-			_f.Set(5, _o5)
-			_f.Set(6, _o6)
-			_f.Set(7, _o7)
-			_f.Set(8, _o8)
-			_f.Set(9, _o9)
-			_f.Set(10, _o10)
-			_f.Set(11, _o11)
-			_f.Set(12, _o12)
+			_f.Set(0, _o12)
+			_f.Set(1, _o13)
+			_f.Set(2, _o14)
+			_f.Set(3, _o15)
+			_f.Set(4, _o16)
+			_f.Set(5, _o17)
+			_f.Set(6, _o18)
+			_f.Set(7, _o19)
+			_f.Set(8, _o20)
+			_f.Set(9, _o21)
+			_f.Set(10, _o22)
+			_f.Set(11, _o23)
+			_f.Set(12, _o24)
 			_c.Store(_fp, _f)
 		} else {
 			_c.Pop()
@@ -2399,79 +2495,219 @@ func Range10ClosureHeterogenousCapture() {
 	case _f.IP < 11:
 		switch {
 		case _f.IP < 2:
-			_o0 = 0
+			_o12 = 0
 			_f.IP = 2
 			fallthrough
 		case _f.IP < 3:
-			_o1 = 1
+			_o13 = 1
 			_f.IP = 3
 			fallthrough
 		case _f.IP < 4:
-			_o2 = 2
+			_o14 = 2
 			_f.IP = 4
 			fallthrough
 		case _f.IP < 5:
-			_o3 = 3
+			_o15 = 3
 			_f.IP = 5
 			fallthrough
 		case _f.IP < 6:
-			_o4 = 4
+			_o16 = 4
 			_f.IP = 6
 			fallthrough
 		case _f.IP < 7:
-			_o5 = 5
+			_o17 = 5
 			_f.IP = 7
 			fallthrough
 		case _f.IP < 8:
-			_o6 = 6
+			_o18 = 6
 			_f.IP = 8
 			fallthrough
 		case _f.IP < 9:
-			_o7 = 7
+			_o19 = 7
 			_f.IP = 9
 			fallthrough
 		case _f.IP < 10:
-			_o8 = 8
+			_o20 = 8
 			_f.IP = 10
 			fallthrough
 		case _f.IP < 11:
-			_o9 = func() int { return int(_o8) + 1 }
+			_o21 = func() int { return int(_o20) + 1 }
 		}
 		_f.IP = 11
 		fallthrough
 	case _f.IP < 12:
 
-		_o10 = 0
+		_o22 = 0
 		_f.IP = 12
 		fallthrough
 	case _f.IP < 13:
-		_o11 = func() bool {
-			var v int
-			switch _o10 {
-			case 0:
-				v = int(_o0)
-			case 1:
-				v = int(_o1)
-			case 2:
-				v = int(_o2)
-			case 3:
-				v = int(_o3)
-			case 4:
-				v = int(_o4)
-			case 5:
-				v = int(_o5)
-			case 6:
-				v = int(_o6)
-			case 7:
-				v = int(_o7)
-			case 8:
-				v = int(_o8)
-			case 9:
-				v = _o9()
+		_o23 = func() (_ bool) {
+			_c := coroutine.LoadContext[int, any]()
+			_f, _fp := _c.Push()
+			var _o0 int
+			var _o1 int
+			var _o2 bool
+			var _o3 bool
+			var _o4 bool
+			var _o5 bool
+			var _o6 bool
+			var _o7 bool
+			var _o8 bool
+			var _o9 bool
+			var _o10 bool
+			var _o11 bool
+			if _f.IP > 0 {
+				if _v := _f.Get(0); _v != nil {
+					_o0 = _v.(int)
+				}
+				if _v := _f.Get(1); _v != nil {
+					_o1 = _v.(int)
+				}
+				if _v := _f.Get(2); _v != nil {
+					_o2 = _v.(bool)
+				}
+				if _v := _f.Get(3); _v != nil {
+					_o3 = _v.(bool)
+				}
+				if _v := _f.Get(4); _v != nil {
+					_o4 = _v.(bool)
+				}
+				if _v := _f.Get(5); _v != nil {
+					_o5 = _v.(bool)
+				}
+				if _v := _f.Get(6); _v != nil {
+					_o6 = _v.(bool)
+				}
+				if _v := _f.Get(7); _v != nil {
+					_o7 = _v.(bool)
+				}
+				if _v := _f.Get(8); _v != nil {
+					_o8 = _v.(bool)
+				}
+				if _v := _f.Get(9); _v != nil {
+					_o9 = _v.(bool)
+				}
+				if _v := _f.Get(10); _v != nil {
+					_o10 = _v.(bool)
+				}
+				if _v := _f.Get(11); _v != nil {
+					_o11 = _v.(bool)
+				}
 			}
-			coroutine.Yield[int, any](v)
-			_o10++
-			return _o10 < 10
+			defer func() {
+				if _c.Unwinding() {
+					_f.Set(0, _o0)
+					_f.Set(1, _o1)
+					_f.Set(2, _o2)
+					_f.Set(3, _o3)
+					_f.Set(4, _o4)
+					_f.Set(5, _o5)
+					_f.Set(6, _o6)
+					_f.Set(7, _o7)
+					_f.Set(8, _o8)
+					_f.Set(9, _o9)
+					_f.Set(10, _o10)
+					_f.Set(11, _o11)
+					_c.Store(_fp, _f)
+				} else {
+					_c.Pop()
+				}
+			}()
+			switch {
+			case _f.IP < 2:
+				_f.IP = 2
+				fallthrough
+			case _f.IP < 23:
+				switch {
+				case _f.IP < 3:
+					_o1 = _o22
+					_f.IP = 3
+					fallthrough
+				case _f.IP < 23:
+					switch {
+					default:
+						switch {
+						case _f.IP < 4:
+							_o2 = _o1 ==
+								0
+							_f.IP = 4
+							fallthrough
+						case _f.IP < 23:
+							if _o2 {
+								_o0 = int(_o12)
+							} else {
+								_o3 = _o1 ==
+									1
+								if _o3 {
+									_o0 = int(_o13)
+								} else {
+									_o4 = _o1 ==
+										2
+									if _o4 {
+										_o0 = int(_o14)
+									} else {
+										_o5 = _o1 ==
+											3
+										if _o5 {
+											_o0 = int(_o15)
+										} else {
+											_o6 = _o1 ==
+												4
+											if _o6 {
+												_o0 = int(_o16)
+											} else {
+												_o7 = _o1 ==
+													5
+												if _o7 {
+													_o0 = int(_o17)
+												} else {
+													_o8 = _o1 ==
+														6
+													if _o8 {
+														_o0 = int(_o18)
+													} else {
+														_o9 = _o1 ==
+															7
+														if _o9 {
+															_o0 = int(_o19)
+														} else {
+															_o10 = _o1 ==
+																8
+															if _o10 {
+																_o0 = int(_o20)
+															} else {
+																_o11 = _o1 ==
+																	9
+																if _o11 {
+																	_o0 = _o21()
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				_f.IP = 23
+				fallthrough
+			case _f.IP < 24:
+
+				coroutine.Yield[int, any](_o0)
+				_f.IP = 24
+				fallthrough
+			case _f.IP < 25:
+				_o22++
+				_f.IP = 25
+				fallthrough
+			case _f.IP < 26:
+				return _o22 < 10
+			}
+			return
 		}
 		_f.IP = 13
 		fallthrough
@@ -2480,11 +2716,11 @@ func Range10ClosureHeterogenousCapture() {
 		for ; ; _f.IP = 13 {
 			switch {
 			case _f.IP < 14:
-				_o12 = !_o11()
+				_o24 = !_o23()
 				_f.IP = 14
 				fallthrough
 			case _f.IP < 15:
-				if _o12 {
+				if _o24 {
 					break _l0
 				}
 			}

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"slices"
 	"strconv"
 )
 
@@ -96,4 +97,24 @@ func newFields(tuple *types.Tuple) []*ast.Field {
 		}
 	}
 	return fields
+}
+
+func funcTypeWithNamedResults(t *ast.FuncType) *ast.FuncType {
+	if t.Results == nil {
+		return t
+	}
+	funcType := *t
+	funcType.Results = &ast.FieldList{
+		List: slices.Clone(t.Results.List),
+	}
+	for i, f := range t.Results.List {
+		if len(f.Names) == 0 {
+			field := *f
+			field.Names = []*ast.Ident{
+				ast.NewIdent("_"),
+			}
+			funcType.Results.List[i] = &field
+		}
+	}
+	return &funcType
 }


### PR DESCRIPTION
Follow up to #45, we now support compiling function literals declared within other functions; as in, turning closures into coroutines.