### PR TITLE
Add imports to generated functypes file

### DIFF
--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -290,7 +290,7 @@ func (c *compiler) compilePackage(p *packages.Package, colors functionColors, pr
 		return err
 	}
 
-	functypesFile := generateFunctypes(prog.Package(p.Types), colors)
+	functypesFile := generateFunctypes(p, prog.Package(p.Types), colors)
 	functypesPath := filepath.Join(packageDir, "coroutine_functypes.go")
 	if err := c.writeFile(functypesPath, functypesFile); err != nil {
 		return err
@@ -306,9 +306,10 @@ func addImports(p *packages.Package, gen *ast.File) *ast.File {
 		switch x := n.(type) {
 		case *ast.SelectorExpr:
 			ident, ok := x.X.(*ast.Ident)
-			if !ok {
+			if !ok || ident.Name == "" {
 				break
 			}
+
 			obj := p.TypesInfo.ObjectOf(ident)
 			pkgname, ok := obj.(*types.PkgName)
 			if !ok {
@@ -316,6 +317,9 @@ func addImports(p *packages.Package, gen *ast.File) *ast.File {
 			}
 
 			pkg := pkgname.Imported().Path()
+			if pkg == "" {
+				break
+			}
 
 			if existing, ok := imports[ident.Name]; ok && existing != pkg {
 				fmt.Println("existing:", ident.Name, existing)
@@ -326,6 +330,10 @@ func addImports(p *packages.Package, gen *ast.File) *ast.File {
 		}
 		return true
 	})
+
+	if len(imports) == 0 {
+		return gen
+	}
 
 	importspecs := make([]ast.Spec, 0, len(imports))
 	for name, path := range imports {
@@ -425,7 +433,7 @@ func (scope *scope) compileFuncLit(p *packages.Package, fn *ast.FuncLit, color *
 }
 
 func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body *ast.BlockStmt, color *types.Signature) *ast.BlockStmt {
-	body = desugar(p.Types, body, p.TypesInfo).(*ast.BlockStmt)
+	body = desugar(p, body).(*ast.BlockStmt)
 	body = astutil.Apply(body,
 		func(cursor *astutil.Cursor) bool {
 			switch n := cursor.Node().(type) {
@@ -450,8 +458,8 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 	fp := ast.NewIdent("_fp")
 
 	yieldTypeExpr := make([]ast.Expr, 2)
-	yieldTypeExpr[0] = typeExpr(p.Types, color.Params().At(0).Type())
-	yieldTypeExpr[1] = typeExpr(p.Types, color.Results().At(0).Type())
+	yieldTypeExpr[0] = typeExpr(p, color.Params().At(0).Type())
+	yieldTypeExpr[1] = typeExpr(p, color.Results().At(0).Type())
 
 	// _c := coroutine.LoadContext[R, S]()
 	gen.List = append(gen.List, &ast.AssignStmt{
@@ -494,7 +502,7 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 	// declarations to the function prologue. We downgrade inline var decls and
 	// assignments that use := to assignments that use =. Constant decls are
 	// hoisted and also have their value assigned in the function prologue.
-	decls := extractDecls(p.Types, body, p.TypesInfo)
+	decls := extractDecls(p, body, p.TypesInfo)
 	renameObjects(body, p.TypesInfo, decls, scope)
 	for _, decl := range decls {
 		gen.List = append(gen.List, &ast.DeclStmt{Decl: decl})
@@ -547,7 +555,7 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 							Lhs: []ast.Expr{name},
 							Tok: token.ASSIGN,
 							Rhs: []ast.Expr{
-								&ast.TypeAssertExpr{X: value, Type: typeExpr(p.Types, saveAndRestoreTypes[i])},
+								&ast.TypeAssertExpr{X: value, Type: typeExpr(p, saveAndRestoreTypes[i])},
 							},
 						},
 					},

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -168,6 +168,12 @@ func TestCoroutineYield(t *testing.T) {
 				-15, 15, 150, // type switch
 			},
 		},
+
+		{
+			name:   "yield imported type time.Duration",
+			coro:   YieldingDurations,
+			yields: []int{100, 101, 102, 103, 104, 105, 106, 107, 108, 109},
+		},
 	}
 
 	// This emulates the installation of function type information by the

--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -6,6 +6,7 @@ import (
 	"go/types"
 
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
 )
 
 // extractDecls extracts type, constant and variable declarations
@@ -20,7 +21,7 @@ import (
 // Note that declarations are extracted from all nested scopes within the
 // function body, so there may be duplicate identifiers. Identifiers can be
 // disambiguated using (*types.Info).ObjectOf(ident).
-func extractDecls(p *types.Package, tree ast.Node, info *types.Info) (decls []*ast.GenDecl) {
+func extractDecls(p *packages.Package, tree ast.Node, info *types.Info) (decls []*ast.GenDecl) {
 	ast.Inspect(tree, func(node ast.Node) bool {
 		switch n := node.(type) {
 		case *ast.FuncLit:

--- a/compiler/desugar.go
+++ b/compiler/desugar.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
 )
 
 // desugar recursively replaces sugared AST nodes with simpler constructs.
@@ -39,7 +40,8 @@ import (
 // types.Info. If this gets unruly in the future, desugaring should be
 // performed after parsing AST's but before type checking so that this is
 // done automatically by the type checker.
-func desugar(p *types.Package, stmt ast.Stmt, info *types.Info) ast.Stmt {
+func desugar(p *packages.Package, stmt ast.Stmt) ast.Stmt {
+	info := p.TypesInfo
 	d := desugarer{pkg: p, info: info}
 	stmt = d.desugar(stmt, nil, nil, nil)
 
@@ -56,7 +58,7 @@ func desugar(p *types.Package, stmt ast.Stmt, info *types.Info) ast.Stmt {
 }
 
 type desugarer struct {
-	pkg          *types.Package
+	pkg          *packages.Package
 	info         *types.Info
 	vars         int
 	labels       int

--- a/compiler/desugar_test.go
+++ b/compiler/desugar_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestDesugar(t *testing.T) {
@@ -1204,7 +1205,8 @@ _l0:
 				}
 				return true
 			})
-			desugared := desugar(nil, body, info)
+			p := &packages.Package{TypesInfo: info}
+			desugared := desugar(p, body)
 			desugared = unnestBlocks(desugared)
 
 			expect := strings.TrimSpace(test.expect)

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -486,3 +486,17 @@ func b(v int) int {
 	coroutine.Yield[int, any](-v)
 	return v
 }
+
+func YieldingDurations() {
+	t := new(time.Duration)
+	*t = time.Duration(100)
+
+	f := func() {
+		i := int(t.Nanoseconds())
+		*t = time.Duration(i + 1)
+		coroutine.Yield[int, any](i)
+	}
+	for i := 0; i < 10; i++ {
+		f()
+	}
+}

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -4205,3 +4205,139 @@ func b(v int) (_ int) {
 	}
 	return
 }
+
+func YieldingDurations() {
+	_c := coroutine.LoadContext[int, any]()
+	_f, _fp := _c.Push()
+	var _o3 *time.Duration
+	var _o4 time.Duration
+	var _o5 func()
+	var _o6 int
+	var _o7 bool
+	if _f.IP > 0 {
+		if _v := _f.Get(0); _v != nil {
+			_o3 = _v.(*time.Duration)
+		}
+		if _v := _f.Get(1); _v != nil {
+			_o4 = _v.(time.Duration)
+		}
+		if _v := _f.Get(2); _v != nil {
+
+			_o5 = _v.(func())
+		}
+		if _v := _f.Get(3); _v != nil {
+
+			_o6 = _v.(int)
+		}
+		if _v := _f.Get(4); _v != nil {
+			_o7 = _v.(bool)
+		}
+	}
+	defer func() {
+		if _c.Unwinding() {
+			_f.Set(0, _o3)
+			_f.Set(1, _o4)
+			_f.Set(2, _o5)
+			_f.Set(3, _o6)
+			_f.Set(4, _o7)
+			_c.Store(_fp, _f)
+		} else {
+			_c.Pop()
+		}
+	}()
+	switch {
+	case _f.IP < 2:
+		_o3 = new(time.Duration)
+		_f.IP = 2
+		fallthrough
+	case _f.IP < 3:
+		_o4 = time.Duration(100)
+		_f.IP = 3
+		fallthrough
+	case _f.IP < 4:
+		*_o3 = _o4
+		_f.IP = 4
+		fallthrough
+	case _f.IP < 5:
+
+		_o5 = func() {
+			_c := coroutine.LoadContext[int, any]()
+			_f, _fp := _c.Push()
+			var _o0 int64
+			var _o1 int
+			var _o2 time.Duration
+			if _f.IP > 0 {
+				if _v := _f.Get(0); _v != nil {
+					_o0 = _v.(int64)
+				}
+				if _v := _f.Get(1); _v != nil {
+					_o1 = _v.(int)
+				}
+				if _v := _f.Get(2); _v != nil {
+					_o2 = _v.(time.Duration)
+				}
+			}
+			defer func() {
+				if _c.Unwinding() {
+					_f.Set(0, _o0)
+					_f.Set(1, _o1)
+					_f.Set(2, _o2)
+					_c.Store(_fp, _f)
+				} else {
+					_c.Pop()
+				}
+			}()
+			switch {
+			case _f.IP < 2:
+				_o0 = _o3.Nanoseconds()
+				_f.IP = 2
+				fallthrough
+			case _f.IP < 3:
+				_o1 = int(_o0)
+				_f.IP = 3
+				fallthrough
+			case _f.IP < 4:
+				_o2 = time.Duration(_o1 + 1)
+				_f.IP = 4
+				fallthrough
+			case _f.IP < 5:
+				*_o3 = _o2
+				_f.IP = 5
+				fallthrough
+			case _f.IP < 6:
+				coroutine.Yield[int, any](_o1)
+			}
+		}
+		_f.IP = 5
+		fallthrough
+	case _f.IP < 9:
+		switch {
+		case _f.IP < 6:
+
+			_o6 = 0
+			_f.IP = 6
+			fallthrough
+		case _f.IP < 9:
+		_l0:
+			for ; ; _o6, _f.IP = _o6+1, 6 {
+				switch {
+				case _f.IP < 8:
+					switch {
+					case _f.IP < 7:
+						_o7 = !(_o6 < 10)
+						_f.IP = 7
+						fallthrough
+					case _f.IP < 8:
+						if _o7 {
+							break _l0
+						}
+					}
+					_f.IP = 8
+					fallthrough
+				case _f.IP < 9:
+					_o5()
+				}
+			}
+		}
+	}
+}

--- a/compiler/testdata/coroutine_functypes.go
+++ b/compiler/testdata/coroutine_functypes.go
@@ -4,6 +4,7 @@
 
 package testdata
 
+import time "time"
 import _types "github.com/stealthrocket/coroutine/types"
 
 func init() {
@@ -61,6 +62,11 @@ func init() {
 	_types.RegisterFunc[func(int)]("github.com/stealthrocket/coroutine/compiler/testdata.SquareGeneratorTwice")
 	_types.RegisterFunc[func(int)]("github.com/stealthrocket/coroutine/compiler/testdata.SquareGeneratorTwiceLoop")
 	_types.RegisterFunc[func(int)]("github.com/stealthrocket/coroutine/compiler/testdata.TypeSwitchingGenerator")
+	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.YieldingDurations")
+	_types.RegisterClosure[func(), struct {
+		_ uintptr
+		t **time.Duration
+	}]("github.com/stealthrocket/coroutine/compiler/testdata.YieldingDurations.func2")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.YieldingExpressionDesugaring")
 	_types.RegisterFunc[func(int) int]("github.com/stealthrocket/coroutine/compiler/testdata.a")
 	_types.RegisterFunc[func(int) int]("github.com/stealthrocket/coroutine/compiler/testdata.b")


### PR DESCRIPTION
To properly add imports, the ident used in the generated types need to be recorded in the package's TypeInfo. There is a risk of two files in the same package trying to import different packages under the same name. The compiler will stop and report the issue if that happens, but we should consider adding a pre-pass to normalize all imports in the package (remove dot imports, qualify them all with unique names, etc.)

Fixes #57