### PR TITLE
coroc: better handling of dependencies that haven't been vendored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
+GO ?= go
+
 all: test
 
 test:
-	go test ./...
-	go test --tags=durable ./...
+	$(GO) test ./...
+	$(GO) test --tags=durable ./...
 	$(MAKE) -C compiler $@
+
+.PHONY: fmt
+fmt:
+	$(GO) fmt ./...
+
+.PHONY: lint
+lint:
+	which golangci-lint >/dev/null && golangci-lint run
 
 clean:
 	$(MAKE) -C compiler $@


### PR DESCRIPTION
The compiler will reject packages that cannot be mutated safely (because the mutations would be visible to other builds). However, the current error it uses is cryptic:

```
error: package some/package (/path/to/some/package) is not in GOROOT (/usr/local/go)
```

The compiler attempts to vendor packages that aren't part of the input module, and assumes that all such packages exist under `GOROOT`. This is not a valid assumption, since the module may have dependencies that haven't been vendored.

This PR relaxes the check so that it accepts packages under `$MODULEDIR/vendor`, and improves the error message when dependencies haven't been vendored:

```
error: cannot mutate package some/package (/path/to/some/package) safely. Please vendor dependencies: go mod vendor
```