### PR TITLE
coroc: better handle chained function calls

### DIFF
--- a/compiler/desugar_test.go
+++ b/compiler/desugar_test.go
@@ -1136,6 +1136,16 @@ defer func() {
 }
 `,
 		},
+		{
+			name: "repeated function calls",
+			body: "time.Now().UTC()",
+			expect: `
+{
+	_v0 := time.Now()
+	_v0.UTC()
+}
+`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			expr, err := parser.ParseExpr("func() {\n" + test.body + "\n}()")


### PR DESCRIPTION
This fixes some odd expression decomposition I noticed. In the worst case (all functions in the chain may yield), a chain like `time.Now().UTC()` is decomposed to:

```go
{
    _v2 := time.Now
    _v1 := _v2()
    _v0 := _v1.UTC
    _v0()
}
```

Although this is technically correct, it can cause issues with serialization because the function types aren't necessarily registered.

This PR improves the handling of `ast.CallExpr` + `ast.SelectorExpr` so that we instead get the following (in the worst case):

```go
{
    _v0 := time.Now()
    _v0.UTC()
}
```