### PR TITLE
Additional type support in serialization layer

### DIFF
--- a/types/reflect.go
+++ b/types/reflect.go
@@ -217,6 +217,12 @@ func serializeReflectValue(s *Serializer, v reflect.Value) {
 	case reflect.String:
 		s := v.String()
 		p = unsafe.Pointer(&s)
+	case reflect.Slice:
+		var s slice
+		s.data = v.UnsafePointer()
+		s.len = v.Len()
+		s.cap = v.Cap()
+		p = unsafe.Pointer(&s)
 	case reflect.Func:
 		fp := v.Pointer()
 		indirect := unsafe.Pointer(&fp)
@@ -267,6 +273,9 @@ func deserializeReflectValue(d *Deserializer, t reflect.Type, p unsafe.Pointer) 
 		v = reflect.ValueOf(*(*complex128)(p))
 	case reflect.String:
 		v = reflect.ValueOf(*(*string)(p))
+	case reflect.Slice:
+		v = reflect.New(rt).Elem()
+		*(*slice)(unsafe.Pointer(v.UnsafeAddr())) = *(*slice)(p)
 	case reflect.Func:
 		fn := *(**Func)(p)
 		v = reflect.New(rt).Elem()

--- a/types/reflect.go
+++ b/types/reflect.go
@@ -213,11 +213,14 @@ func serializeReflectValue(s *Serializer, t reflect.Type, v reflect.Value) {
 	case reflect.Map:
 		serializeMapReflect(s, t, v)
 	case reflect.Func:
-		if f := v.Pointer(); f != 0 {
-			indirect := unsafe.Pointer(&f)
+		if addr := v.Pointer(); addr != 0 {
+			if fn := FuncByAddr(addr); fn != nil && fn.Closure != nil {
+				panic("not implemented: serializing reflect.Value(closure)")
+			}
+			indirect := unsafe.Pointer(&addr)
 			serializeFunc(s, t, unsafe.Pointer(&indirect))
 		} else {
-			serializeFunc(s, t, unsafe.Pointer(&f))
+			serializeFunc(s, t, unsafe.Pointer(&addr))
 		}
 	default:
 		panic(fmt.Sprintf("not implemented: serializing reflect.Value with type %s", t))

--- a/types/reflect.go
+++ b/types/reflect.go
@@ -267,6 +267,11 @@ func deserializeReflectValue(d *Deserializer, t reflect.Type, p unsafe.Pointer) 
 		v = reflect.ValueOf(*(*complex128)(p))
 	case reflect.String:
 		v = reflect.ValueOf(*(*string)(p))
+	case reflect.Func:
+		fn := *(**Func)(p)
+		v = reflect.New(rt).Elem()
+		p := unsafe.Pointer(v.UnsafeAddr())
+		*(*unsafe.Pointer)(p) = unsafe.Pointer(&fn.Addr)
 	default:
 		panic(fmt.Sprintf("not implemented: deserializing reflect.Value with type %s", rt))
 	}

--- a/types/reflect.go
+++ b/types/reflect.go
@@ -388,9 +388,11 @@ func serializeFunc(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 	// memory location starting with the address of the function, hence the
 	// double indirection here.
 	p = *(*unsafe.Pointer)(p)
-	if p == nil { // nil function value?
-		panic("cannot serialize nil function values yet")
+	if p == nil { // nil function value
+		serializeBool(s, false)
+		return
 	}
+	serializeBool(s, true)
 
 	fn := FuncByAddr(*(*uintptr)(p))
 	serializeString(s, &fn.Name)
@@ -404,6 +406,13 @@ func serializeFunc(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 }
 
 func deserializeFunc(d *Deserializer, t reflect.Type, p unsafe.Pointer) {
+	var ok bool
+	deserializeBool(d, &ok)
+	if !ok {
+		*(**Func)(p) = nil
+		return
+	}
+
 	var name string
 	deserializeString(d, &name)
 

--- a/types/reflect.go
+++ b/types/reflect.go
@@ -230,8 +230,10 @@ func serializeReflectValue(s *Serializer, t reflect.Type, v reflect.Value) {
 		} else {
 			serializeFunc(s, t, unsafe.Pointer(&addr))
 		}
+	case reflect.Pointer:
+		serializePointedAt(s, t.Elem(), v.UnsafePointer())
 	default:
-		panic(fmt.Sprintf("not implemented: serializing reflect.Value with type %s", t))
+		panic(fmt.Sprintf("not implemented: serializing reflect.Value with type %s (%s)", t, t.Kind()))
 	}
 }
 
@@ -329,6 +331,10 @@ func deserializeReflectValue(d *Deserializer, t reflect.Type) (v reflect.Value) 
 			p := unsafe.Pointer(v.UnsafeAddr())
 			*(*unsafe.Pointer)(p) = unsafe.Pointer(&fn.Addr)
 		}
+	case reflect.Pointer:
+		ep := deserializePointedAt(d, t.Elem())
+		v = reflect.New(t).Elem()
+		v.Set(ep)
 	default:
 		panic(fmt.Sprintf("not implemented: deserializing reflect.Value with type %s", t))
 	}

--- a/types/reflect.go
+++ b/types/reflect.go
@@ -202,6 +202,11 @@ func serializeReflectValue(s *Serializer, t reflect.Type, v reflect.Value) {
 	case reflect.String:
 		str := v.String()
 		serializeString(s, &str)
+	case reflect.Array:
+		et := t.Elem()
+		for i := 0; i < t.Len(); i++ {
+			serializeReflectValue(s, et, v.Index(i))
+		}
 	case reflect.Slice:
 		sl := slice{data: v.UnsafePointer(), len: v.Len(), cap: v.Cap()}
 		serializeSlice(s, t, unsafe.Pointer(&sl))
@@ -285,6 +290,9 @@ func deserializeReflectValue(d *Deserializer, t reflect.Type, p unsafe.Pointer) 
 		var value string
 		deserializeString(d, &value)
 		v = reflect.ValueOf(value)
+	case reflect.Array:
+		v = reflect.New(t).Elem()
+		deserializeArray(d, t, unsafe.Pointer(v.UnsafeAddr()))
 	case reflect.Slice:
 		var value slice
 		deserializeSlice(d, t, unsafe.Pointer(&value))

--- a/types/scan.go
+++ b/types/scan.go
@@ -249,6 +249,10 @@ func scan(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 	}
 	s.scanptrs[r] = struct{}{}
 
+	if r.IsNil() {
+		return
+	}
+
 	switch t.Kind() {
 	case reflect.Invalid:
 		panic("handling invalid reflect.Type")
@@ -262,6 +266,9 @@ func scan(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 		}
 	case reflect.Slice:
 		sr := r.Elem()
+		if sr.IsNil() {
+			return
+		}
 		ep := sr.UnsafePointer()
 		if ep == nil {
 			return
@@ -278,9 +285,15 @@ func scan(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 			scan(s, et, ep)
 		}
 	case reflect.Interface:
-		et := reflect.TypeOf(r.Elem().Interface())
+		if r.Elem().IsNil() {
+			return
+		}
+		it := r.Elem().Interface()
+		if it == nil {
+			return
+		}
+		et := reflect.TypeOf(it)
 		eptr := (*iface)(p).ptr
-
 		if eptr == nil {
 			return
 		}
@@ -300,6 +313,9 @@ func scan(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 			scan(s, ft, fp)
 		}
 	case reflect.Pointer:
+		if r.Elem().IsNil() {
+			return
+		}
 		ep := r.Elem().UnsafePointer()
 		scan(s, t.Elem(), ep)
 	case reflect.String:

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -133,6 +133,9 @@ func TestReflect(t *testing.T) {
 			reflect.ValueOf(float32(3.14)),
 			reflect.ValueOf(float64(math.MaxFloat64)),
 
+			// Arrays
+			reflect.ValueOf([32]byte{0: 1, 15: 2, 31: 3}),
+
 			// Slices
 			reflect.ValueOf([]byte("foo")),
 			reflect.ValueOf([][]byte{[]byte("foo"), []byte("bar")}),
@@ -764,8 +767,16 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 		return v1.Complex() == v2.Complex()
 	case reflect.String:
 		return v1.String() == v2.String()
-	case reflect.Func:
-		return v1.UnsafePointer() == v2.UnsafePointer()
+	case reflect.Array:
+		if v1.Len() != v2.Len() {
+			return false
+		}
+		for i := 0; i < v1.Len(); i++ {
+			if !equalReflectValue(v1.Index(i), v2.Index(i)) {
+				return false
+			}
+		}
+		return true
 	case reflect.Slice:
 		if v1.Len() != v2.Len() {
 			return false
@@ -778,6 +789,8 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 			}
 		}
 		return true
+	case reflect.Func:
+		return v1.UnsafePointer() == v2.UnsafePointer()
 	default:
 		panic(fmt.Sprintf("not implemented: comparison of reflect.Value with type %s", v1.Type()))
 	}

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -151,6 +151,9 @@ func TestReflect(t *testing.T) {
 			reflect.ValueOf(http.Header{"Content-Length": []string{"11"}, "X-Forwarded-For": []string{"1.1.1.1", "2.2.2.2"}}),
 			reflect.ValueOf(emptyMap),
 
+			// Structs
+			reflect.ValueOf(struct{ A, B int }{1, 2}),
+
 			// Funcs
 			reflect.ValueOf(identity),
 			reflect.ValueOf(funcType(nil)),
@@ -765,16 +768,22 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 	switch v1.Kind() {
 	case reflect.Bool:
 		return v1.Bool() == v2.Bool()
+
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return v1.Int() == v2.Int()
+
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return v1.Uint() == v2.Uint()
+
 	case reflect.Float32, reflect.Float64:
 		return v1.Float() == v2.Float()
+
 	case reflect.Complex64, reflect.Complex128:
 		return v1.Complex() == v2.Complex()
+
 	case reflect.String:
 		return v1.String() == v2.String()
+
 	case reflect.Array:
 		if v1.Len() != v2.Len() {
 			return false
@@ -785,6 +794,7 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 			}
 		}
 		return true
+
 	case reflect.Slice:
 		if v1.Len() != v2.Len() {
 			return false
@@ -797,6 +807,7 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 			}
 		}
 		return true
+
 	case reflect.Map:
 		if v1.Len() != v2.Len() {
 			return false
@@ -811,8 +822,18 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 			}
 		}
 		return true
+
+	case reflect.Struct:
+		for i := 0; i < v1.NumField(); i++ {
+			if !equalReflectValue(v1.Field(i), v2.Field(i)) {
+				return false
+			}
+		}
+		return true
+
 	case reflect.Func:
 		return v1.UnsafePointer() == v2.UnsafePointer()
+
 	default:
 		panic(fmt.Sprintf("not implemented: comparison of reflect.Value with type %s", v1.Type()))
 	}

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -130,6 +130,11 @@ func TestReflect(t *testing.T) {
 			reflect.ValueOf(uint64(math.MaxUint64)),
 			reflect.ValueOf(float32(3.14)),
 			reflect.ValueOf(float64(math.MaxFloat64)),
+			reflect.ValueOf([]byte("foo")),
+			reflect.ValueOf([][]byte{[]byte("foo"), []byte("bar")}),
+			reflect.ValueOf([]string{"foo", "bar"}),
+			reflect.ValueOf([]int{}),
+			reflect.ValueOf([]int(nil)),
 			reflect.ValueOf(identity),
 		}
 
@@ -688,6 +693,18 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 		return v1.String() == v2.String()
 	case reflect.Func:
 		return v1.UnsafePointer() == v2.UnsafePointer()
+	case reflect.Slice:
+		if v1.Len() != v2.Len() {
+			return false
+		} else if v1.Cap() != v2.Cap() {
+			return false
+		}
+		for i := 0; i < v1.Len(); i++ {
+			if !equalReflectValue(v1.Index(i), v2.Index(i)) {
+				return false
+			}
+		}
+		return true
 	default:
 		panic(fmt.Sprintf("not implemented: comparison of reflect.Value with type %s", v1.Type()))
 	}

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -58,12 +58,16 @@ type EasyStruct struct {
 
 type funcType func(int) error
 
+func identity(v int) int { return v }
+
 func TestReflect(t *testing.T) {
 	withBlankTypeMap(func() {
 		intv := int(100)
 		intp := &intv
 		intpp := &intp
 		type ctxKey1 struct{}
+
+		RegisterFunc[func(int) int]("github.com/stealthrocket/coroutine/types.identity")
 
 		cases := []any{
 			"foo",
@@ -126,6 +130,7 @@ func TestReflect(t *testing.T) {
 			reflect.ValueOf(uint64(math.MaxUint64)),
 			reflect.ValueOf(float32(3.14)),
 			reflect.ValueOf(float64(math.MaxFloat64)),
+			reflect.ValueOf(identity),
 		}
 
 		for _, x := range cases {
@@ -681,8 +686,10 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 		return v1.Complex() == v2.Complex()
 	case reflect.String:
 		return v1.String() == v2.String()
+	case reflect.Func:
+		return v1.UnsafePointer() == v2.UnsafePointer()
 	default:
-		panic(fmt.Sprintf("not implemented: comparison of reflect.Value with type %T", v1))
+		panic(fmt.Sprintf("not implemented: comparison of reflect.Value with type %s", v1.Type()))
 	}
 }
 

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -55,6 +55,8 @@ type EasyStruct struct {
 	B string
 }
 
+type funcType func(int) error
+
 func TestReflect(t *testing.T) {
 	withBlankTypeMap(func() {
 		intv := int(100)
@@ -94,6 +96,8 @@ func TestReflect(t *testing.T) {
 
 			[]any{(*int)(nil)},
 
+			funcType(nil),
+
 			func() {},
 			func(int) int { return 42 },
 
@@ -113,8 +117,9 @@ func TestReflect(t *testing.T) {
 
 			if t.Kind() == reflect.Func {
 				a := FuncAddr(x)
-				f := FuncByAddr(a)
-				f.Type = t
+				if f := FuncByAddr(a); f != nil {
+					f.Type = t
+				}
 			}
 		}
 

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -154,6 +154,9 @@ func TestReflect(t *testing.T) {
 			// Structs
 			reflect.ValueOf(struct{ A, B int }{1, 2}),
 
+			// Pointers
+			reflect.ValueOf(errors.New("fail")),
+
 			// Funcs
 			reflect.ValueOf(identity),
 			reflect.ValueOf(funcType(nil)),
@@ -833,6 +836,12 @@ func equalReflectValue(v1, v2 reflect.Value) bool {
 
 	case reflect.Func:
 		return v1.UnsafePointer() == v2.UnsafePointer()
+
+	case reflect.Pointer:
+		if v1.IsNil() != v2.IsNil() {
+			return false
+		}
+		return v1.IsNil() || equalReflectValue(v1.Elem(), v2.Elem())
 
 	default:
 		panic(fmt.Sprintf("not implemented: comparison of reflect.Value with type %s", v1.Type()))

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -110,6 +110,7 @@ func TestReflect(t *testing.T) {
 			"",
 			struct{}{},
 			errors.New("test"),
+			unsafe.Pointer(nil),
 		}
 
 		for _, x := range cases {
@@ -141,6 +142,25 @@ func TestReflect(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestReflectUnsafePointer(t *testing.T) {
+	type unsafePointerStruct struct{ p unsafe.Pointer }
+	var selfRef unsafePointerStruct
+	selfRef.p = unsafe.Pointer(&selfRef)
+
+	b := Serialize(&selfRef)
+	out, b, err := Deserialize(b)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(b) > 0 {
+		t.Fatalf("leftover bytes: %d", len(b))
+	}
+
+	res := out.(*unsafePointerStruct)
+	if unsafe.Pointer(res) != unsafe.Pointer(res.p) {
+		t.Errorf("unsafe.Pointer was not restored correctly")
+	}
 }
 
 func TestErrors(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -18,6 +18,7 @@ const (
 	typeSlice
 	typeStruct
 	typeFunc
+	typeChan
 )
 
 // typeinfo represents a type in the serialization format. It is a
@@ -37,13 +38,22 @@ type typeinfo struct {
 	// - typeFunc uses it to store the number of input arguments and whether
 	//   its variadic as the first bit.
 	val int
-	// typeArray, typeSlice, typePointer, and TypeMap use this field to
+	// typeArray, typeSlice, typePointer, typeChan and typeMap use this field to
 	// store the information about the type they contain.
 	elem   *typeinfo
 	key    *typeinfo   // typeMap only
 	fields []Field     // typeStruct only
 	args   []*typeinfo // typeFunc only
+	dir    chanDir     // typeChan only
 }
+
+type chanDir int
+
+const (
+	recvDir chanDir             = 1 << iota // <-chan
+	sendDir                                 // chan<-
+	bothDir = recvDir | sendDir             // chan
+)
 
 func (t *typeinfo) reflectType(tm *typemap) reflect.Type {
 	if t.offset != 0 {
@@ -126,6 +136,17 @@ func (t *typeinfo) reflectType(tm *typemap) reflect.Type {
 			insouts[i] = tm.ToReflect(t)
 		}
 		return reflect.FuncOf(insouts[:in], insouts[in:], variadic)
+	case typeChan:
+		var dir reflect.ChanDir
+		switch t.dir {
+		case recvDir:
+			dir = reflect.RecvDir
+		case sendDir:
+			dir = reflect.SendDir
+		case bothDir:
+			dir = reflect.BothDir
+		}
+		return reflect.ChanOf(dir, tm.ToReflect(t.elem))
 	}
 	panic(fmt.Errorf("unknown typekind: %d", t.kind))
 }
@@ -245,6 +266,17 @@ func (m *typemap) ToType(t reflect.Type) *typeinfo {
 		ti.kind = typeFunc
 		ti.val = nin<<1 | boolint(t.IsVariadic())
 		ti.args = types
+	case reflect.Chan:
+		ti.kind = typeChan
+		ti.elem = m.ToType(t.Elem())
+		switch t.ChanDir() {
+		case reflect.RecvDir:
+			ti.dir = recvDir
+		case reflect.SendDir:
+			ti.dir = sendDir
+		case reflect.BothDir:
+			ti.dir = bothDir
+		}
 	default:
 		panic(fmt.Errorf("unsupported reflect.Kind (%s)", t.Kind()))
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"unsafe"
 )
 
 type typekind int
@@ -96,6 +97,9 @@ func (t *typeinfo) reflectType(tm *typemap) reflect.Type {
 			panic("Basic type unknown")
 		}
 	case typePointer:
+		if t.elem == nil {
+			return reflect.TypeOf(unsafe.Pointer(nil))
+		}
 		return reflect.PointerTo(tm.ToReflect(t.elem))
 	case typeMap:
 		return reflect.MapOf(tm.ToReflect(t.key), tm.ToReflect(t.elem))
@@ -205,6 +209,9 @@ func (m *typemap) ToType(t reflect.Type) *typeinfo {
 	case reflect.Pointer:
 		ti.kind = typePointer
 		ti.elem = m.ToType(t.Elem())
+	case reflect.UnsafePointer:
+		ti.kind = typePointer
+		ti.elem = nil
 	case reflect.Slice:
 		ti.kind = typeSlice
 		ti.elem = m.ToType(t.Elem())


### PR DESCRIPTION
The serialization layer can now handle:
* nil function pointers
* certain `unsafe.Pointer` values (nil, and pointers that point to some other object in the serializable graph)
* many types of `reflect.Value`