### PR TITLE
Return values

### DIFF
--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -213,14 +213,15 @@ func TestCoroutineYield(t *testing.T) {
 	// compiler because we are not doing codegen for the test files in this
 	// package.
 	for _, test := range tests {
-		var addr uintptr
 		if test.coro != nil {
-			addr = types.FuncAddr(test.coro)
+			addr := types.FuncAddr(test.coro)
+			fn := types.FuncByAddr(addr)
+			types.RegisterFunc[func()](fn.Name)
 		} else {
-			addr = types.FuncAddr(test.coroR)
+			addr := types.FuncAddr(test.coroR)
+			fn := types.FuncByAddr(addr)
+			types.RegisterFunc[func() int](fn.Name)
 		}
-		fn := types.FuncByAddr(addr)
-		types.RegisterFunc[func()](fn.Name)
 	}
 
 	for _, test := range tests {

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -19,7 +19,9 @@ func TestCoroutineYield(t *testing.T) {
 	tests := []struct {
 		name   string
 		coro   func()
+		coroR  func() int
 		yields []int
+		result int
 		skip   bool
 	}{
 		{
@@ -198,15 +200,27 @@ func TestCoroutineYield(t *testing.T) {
 			coro:   func() { VarArgs(3) },
 			yields: []int{0, 1, 2},
 		},
+
+		{
+			name:   "return values",
+			coroR:  func() int { return NestedLoops(3) },
+			yields: []int{1, 2, 3, 2, 4, 6, 3, 6, 9, 2, 4, 6, 4, 8, 12, 6, 12, 18, 3, 6, 9, 6, 12, 18, 9, 18, 27},
+			result: 27,
+		},
 	}
 
 	// This emulates the installation of function type information by the
 	// compiler because we are not doing codegen for the test files in this
 	// package.
 	for _, test := range tests {
-		a := types.FuncAddr(test.coro)
-		f := types.FuncByAddr(a)
-		types.RegisterFunc[func()](f.Name)
+		var addr uintptr
+		if test.coro != nil {
+			addr = types.FuncAddr(test.coro)
+		} else {
+			addr = types.FuncAddr(test.coroR)
+		}
+		fn := types.FuncByAddr(addr)
+		types.RegisterFunc[func()](fn.Name)
 	}
 
 	for _, test := range tests {
@@ -215,7 +229,12 @@ func TestCoroutineYield(t *testing.T) {
 				t.Skip("test is disabled")
 			}
 
-			g := coroutine.New[int, any](test.coro)
+			var g coroutine.Coroutine[int, any]
+			if test.coro != nil {
+				g = coroutine.New[int, any](test.coro)
+			} else {
+				g = coroutine.NewWithReturn[int, any](test.coroR)
+			}
 
 			var yield int
 			for g.Next() {
@@ -250,6 +269,11 @@ func TestCoroutineYield(t *testing.T) {
 			}
 			if yield < len(test.yields) {
 				t.Errorf("coroutine did not yield the correct number of times: got %d, expect %d", yield, len(test.yields))
+			}
+			if test.coroR != nil {
+				if got := g.Result(); got != test.result {
+					t.Errorf("unexpected coroutine return value: got %v, want %v", got, test.result)
+				}
 			}
 		})
 	}

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -43,14 +43,17 @@ func EvenSquareGenerator(n int) {
 	}
 }
 
-func NestedLoops(n int) {
+func NestedLoops(n int) int {
+	var count int
 	for i := 1; i <= n; i++ {
 		for j := 1; j <= n; j++ {
 			for k := 1; k <= n; k++ {
 				coroutine.Yield[int, any](i * j * k)
+				count++
 			}
 		}
 	}
+	return count
 }
 
 func FizzBuzzIfGenerator(n int) {

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -167,7 +167,7 @@ func EvenSquareGenerator(_fn0 int) {
 }
 
 //go:noinline
-func NestedLoops(_fn0 int) {
+func NestedLoops(_fn0 int) (_ int) {
 	_c := coroutine.LoadContext[int, any]()
 	var _f0 *struct {
 		IP int
@@ -175,12 +175,14 @@ func NestedLoops(_fn0 int) {
 		X1 int
 		X2 int
 		X3 int
+		X4 int
 	} = coroutine.Push[struct {
 		IP int
 		X0 int
 		X1 int
 		X2 int
 		X3 int
+		X4 int
 	}](&_c.Stack)
 	if _f0.IP == 0 {
 		*_f0 = struct {
@@ -189,6 +191,7 @@ func NestedLoops(_fn0 int) {
 			X1 int
 			X2 int
 			X3 int
+			X4 int
 		}{X0: _fn0}
 	}
 	defer func() {
@@ -198,32 +201,51 @@ func NestedLoops(_fn0 int) {
 	}()
 	switch {
 	case _f0.IP < 2:
-		_f0.X1 = 1
 		_f0.IP = 2
 		fallthrough
-	case _f0.IP < 5:
-		for ; _f0.X1 <= _f0.X0; _f0.X1, _f0.IP = _f0.X1+1, 2 {
-			switch {
-			case _f0.IP < 3:
-				_f0.X2 = 1
-				_f0.IP = 3
-				fallthrough
-			case _f0.IP < 5:
-				for ; _f0.X2 <= _f0.X0; _f0.X2, _f0.IP = _f0.X2+1, 3 {
-					switch {
-					case _f0.IP < 4:
-						_f0.X3 = 1
-						_f0.IP = 4
-						fallthrough
-					case _f0.IP < 5:
-						for ; _f0.X3 <= _f0.X0; _f0.X3, _f0.IP = _f0.X3+1, 4 {
-							coroutine.Yield[int, any](_f0.X1 * _f0.X2 * _f0.X3)
+	case _f0.IP < 7:
+		switch {
+		case _f0.IP < 3:
+			_f0.X2 = 1
+			_f0.IP = 3
+			fallthrough
+		case _f0.IP < 7:
+			for ; _f0.X2 <= _f0.X0; _f0.X2, _f0.IP = _f0.X2+1, 3 {
+				switch {
+				case _f0.IP < 4:
+					_f0.X3 = 1
+					_f0.IP = 4
+					fallthrough
+				case _f0.IP < 7:
+					for ; _f0.X3 <= _f0.X0; _f0.X3, _f0.IP = _f0.X3+1, 4 {
+						switch {
+						case _f0.IP < 5:
+							_f0.X4 = 1
+							_f0.IP = 5
+							fallthrough
+						case _f0.IP < 7:
+							for ; _f0.X4 <= _f0.X0; _f0.X4, _f0.IP = _f0.X4+1, 5 {
+								switch {
+								case _f0.IP < 6:
+									coroutine.Yield[int, any](_f0.X2 * _f0.X3 * _f0.X4)
+									_f0.IP = 6
+									fallthrough
+								case _f0.IP < 7:
+									_f0.X1++
+								}
+							}
 						}
 					}
 				}
 			}
 		}
+		_f0.IP = 7
+		fallthrough
+	case _f0.IP < 8:
+
+		return _f0.X1
 	}
+	return
 }
 
 //go:noinline
@@ -3182,7 +3204,7 @@ func init() {
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Identity")
 	_types.RegisterFunc[func(_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.LoopBreakAndContinue")
 	_types.RegisterFunc[func(_fn1 int)]("github.com/stealthrocket/coroutine/compiler/testdata.MethodGenerator")
-	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.NestedLoops")
+	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.NestedLoops")
 	_types.RegisterFunc[func(_fn0 int, _fn1 func(int))]("github.com/stealthrocket/coroutine/compiler/testdata.Range")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.Range10ClosureCapturingPointers")
 	_types.RegisterClosure[func() (_ bool), struct {

--- a/coroutine.go
+++ b/coroutine.go
@@ -24,6 +24,11 @@ func (c Coroutine[R, S]) Recv() R { return c.ctx.recv }
 // by the coroutine.
 func (c Coroutine[R, S]) Send(v S) { c.ctx.send = v }
 
+// Result is the return value of the coroutine, if it was constructed with
+// NewWithReturn. Result should only be called once Next returns false,
+// indicating that the coroutine finished executing.
+func (c Coroutine[R, S]) Result() R { return c.ctx.result }
+
 // Stop interrupts the coroutine. On the next call to Next, the coroutine will
 // not return from its yield point; instead, it unwinds its call stack, calling
 // each defer statement in the inverse order that they were declared.
@@ -53,12 +58,15 @@ type Context[R, S any] struct {
 	recv R
 	send S
 
+	// Value returned from the coroutine.
+	result R
+
 	// Booleans managing the state of the coroutine.
 	done   bool
 	stop   bool
 	resume bool //nolint
 
-	context
+	context[R]
 }
 
 // Run executes a coroutine to completion, calling f for each value that the

--- a/coroutine_durable.go
+++ b/coroutine_durable.go
@@ -189,6 +189,13 @@ type context[R any] struct {
 	// Entry point of the coroutine, this is captured so the associated
 	// generator can call into the coroutine to start or resume it at the
 	// last yield point.
+	//
+	// The raw func (via New) and func returning R (via NewWithReturn)
+	// are stored separately to work around a limitation with the compiler.
+	// In volatile mode we only store the latter, and support the former
+	// by creating a closure that calls the func() and returns the zero
+	// value R. The compiler does not yet support compiling generic
+	// functions so the strategy doesn't work in durable mode.
 	entry  func()
 	entryR func() R
 	Stack

--- a/coroutine_durable.go
+++ b/coroutine_durable.go
@@ -100,6 +100,7 @@ type serializedCoroutine[R any] struct {
 func (c *Context[R, S]) Marshal() ([]byte, error) {
 	return types.Serialize(&serializedCoroutine[R]{
 		entry:  c.entry,
+		entryR: c.entryR,
 		stack:  c.Stack,
 		resume: c.resume,
 	}), nil
@@ -119,6 +120,7 @@ func (c *Context[R, S]) Unmarshal(b []byte) (int, error) {
 	}
 	s := v.(*serializedCoroutine[R])
 	c.entry = s.entry
+	c.entryR = s.entryR
 	c.Stack = s.stack
 	c.resume = s.resume
 	sn := start - len(b)


### PR DESCRIPTION
This PR adds optional support for coroutine return values.

If the coroutine was constructed with a new `coroutine.NewWithReturn(func () R)` constructor, the return value can be retrieved using:

```go
for c.Next() {
   // handle yields
}
var result R = c.Result()
```

The reason we haven't added support for passing arguments to coroutines is because it's easy to pass in data using a closure. On the other hand, getting data out of coroutines has so far been problematic. Although you can create a final yield point to pass return values out of the coroutine, the issue in #84 arises.

This PR provides a native way to get data out of a coroutine, so that you don't have to manually create a final yield point.

To keep things simple, I chose to reuse the yield type `R` rather than introduce a new generic type parameter for the return value.