### PR TITLE
Synchronize type cache map access/mutations

### DIFF
--- a/types/typemap.go
+++ b/types/typemap.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"unsafe"
 )
 
@@ -146,19 +147,30 @@ func (m *typemap) serdeOf(x reflect.Type) (serde, bool) {
 type doublemap[K, V comparable] struct {
 	fromK map[K]V
 	fromV map[V]K
+
+	mu sync.Mutex
 }
 
 func (m *doublemap[K, V]) getK(k K) (V, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	v, ok := m.fromK[k]
 	return v, ok
 }
 
 func (m *doublemap[K, V]) getV(v V) (K, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	k, ok := m.fromV[v]
 	return k, ok
 }
 
 func (m *doublemap[K, V]) add(k K, v V) V {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.fromK == nil {
 		m.fromK = make(map[K]V)
 		m.fromV = make(map[V]K)


### PR DESCRIPTION
The serialization layer caches types during serialization and deserialization. See [1](https://github.com/stealthrocket/coroutine/blob/d21c0e06b98e87aca6eb4ebfa7901a9e85597d72/types/types.go#L163-L179), [2](https://github.com/stealthrocket/coroutine/blob/d21c0e06b98e87aca6eb4ebfa7901a9e85597d72/types/typemap.go#L99) and [3](https://github.com/stealthrocket/coroutine/blob/d21c0e06b98e87aca6eb4ebfa7901a9e85597d72/types/typemap.go#L146-L169).

If multiple goroutines are serializing or deserializing durable coroutine state concurrently, a `concurrent map read and map write` failure may be observed. This PR fixes the issue by synchronizing goroutines with a mutex.