### PR TITLE
Introspection (part 5) 

### DIFF
--- a/types/reflect.go
+++ b/types/reflect.go
@@ -23,13 +23,9 @@ func deserializeType(d *Deserializer) reflect.Type {
 func serializeAny(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 	if serde, ok := s.serdes.serdeOf(t); ok {
 		offset := len(s.b)
-		s.b = append(s.b, 0, 0, 0, 0) // store a 32-bit size placeholder
+		s.b = append(s.b, 0, 0, 0, 0, 0, 0, 0, 0) // store a 64-bit size placeholder
 		serde.ser(s, t, p)
-		size := len(s.b) - offset
-		if int64(size) > math.MaxUint32 {
-			panic("overflow")
-		}
-		binary.LittleEndian.PutUint32(s.b[offset:], uint32(size))
+		binary.LittleEndian.PutUint64(s.b[offset:], uint64(len(s.b)-offset))
 		return
 	}
 
@@ -102,7 +98,7 @@ func serializeAny(s *Serializer, t reflect.Type, p unsafe.Pointer) {
 
 func deserializeAny(d *Deserializer, t reflect.Type, p unsafe.Pointer) {
 	if serde, ok := d.serdes.serdeOf(t); ok {
-		d.b = d.b[4:] // skip size prefix
+		d.b = d.b[8:] // skip size prefix
 		serde.des(d, t, p)
 		return
 	}

--- a/types/serde.go
+++ b/types/serde.go
@@ -229,6 +229,7 @@ func SerializeT[T any](s *Serializer, x T) {
 		n.Elem().Set(r)
 		p = n.UnsafePointer()
 	}
+	serializeType(s, t)
 	serializeAny(s, t, p)
 }
 
@@ -237,5 +238,9 @@ func DeserializeTo[T any](d *Deserializer, x *T) {
 	r := reflect.ValueOf(x)
 	t := r.Type().Elem()
 	p := r.UnsafePointer()
+	actualType := deserializeType(d)
+	if actualType != t {
+		panic(fmt.Sprintf("cannot deserialize %s as %s", actualType, t))
+	}
 	deserializeAny(d, t, p)
 }


### PR DESCRIPTION
Following on from #111, this PR adds framing to the custom serializer output so that an offline process can walk the object graph without access to the custom deserialization routine. 