### PR TITLE
Introspection (part 7)

### DIFF
--- a/types/inspect.go
+++ b/types/inspect.go
@@ -52,6 +52,7 @@ func (s *State) Type(i int) *Type {
 	return &Type{
 		state: s,
 		typ:   s.state.Types[i],
+		index: i,
 	}
 }
 
@@ -69,6 +70,7 @@ func (s *State) Function(i int) *Function {
 	return &Function{
 		state:    s,
 		function: s.state.Functions[i],
+		index:    i,
 	}
 }
 
@@ -86,6 +88,7 @@ func (s *State) Region(i int) *Region {
 	return &Region{
 		state:  s,
 		region: s.state.Regions[i],
+		index:  i,
 	}
 }
 
@@ -107,6 +110,7 @@ func (s *State) Root() *Region {
 	return &Region{
 		state:  s,
 		region: s.state.Root,
+		index:  -1,
 	}
 }
 
@@ -114,6 +118,12 @@ func (s *State) Root() *Region {
 type Type struct {
 	state *State
 	typ   *coroutinev1.Type
+	index int
+}
+
+// Index is the index of the type in the serialized state.
+func (t *Type) Index() int {
+	return t.index
 }
 
 // Name is the name of the type within the package it was defined.
@@ -529,6 +539,7 @@ func (f *Field) Tag() reflect.StructTag {
 type Function struct {
 	state    *State
 	function *coroutinev1.Function
+	index    int
 }
 
 // Name is the name of the function.
@@ -537,6 +548,11 @@ func (f *Function) Name() string {
 		return ""
 	}
 	return f.state.String(int(f.function.Name - 1))
+}
+
+// Index is the index of the function in the serialized state.
+func (f *Function) Index() int {
+	return f.index
 }
 
 // Type is the type of the function.
@@ -567,6 +583,13 @@ func (f *Function) String() string {
 type Region struct {
 	state  *State
 	region *coroutinev1.Region
+	index  int
+}
+
+// Index is the index of the region in the serialized state,
+// or -1 if this is the root region.
+func (t *Region) Index() int {
+	return t.index
 }
 
 // Type is the type of the region.

--- a/types/serde.go
+++ b/types/serde.go
@@ -49,9 +49,6 @@ func Serialize(x any) ([]byte, error) {
 	// Scan pointers to collect memory regions.
 	s.scan(t, p)
 
-	rootType := reflect.TypeOf(wr.Elem().Interface())
-	rootTypeID := s.types.ToType(rootType)
-
 	serializeAny(s, t, p)
 
 	state := &coroutinev1.State{
@@ -61,7 +58,7 @@ func Serialize(x any) ([]byte, error) {
 		Strings:   s.strings.strings,
 		Regions:   s.regions,
 		Root: &coroutinev1.Region{
-			Type: rootTypeID,
+			Type: s.types.ToType(t),
 			Data: s.b,
 		},
 	}

--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -49,8 +49,34 @@ func testSerdeTime(t *testing.T, x time.Time) {
 		t.Fatal(err)
 	}
 
+	assertCanInspect(t, b)
+
 	if !x.Equal(out.(time.Time)) {
 		t.Errorf("expected %v, got %v", x, out)
+	}
+}
+
+func assertCanInspect(t *testing.T, b []byte) {
+	c, err := Inspect(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	regions := []*Region{c.Root()}
+	for i := 0; i < c.NumRegion(); i++ {
+		regions = append(regions, c.Region(i))
+	}
+	for _, region := range regions {
+		if typ := region.Type(); typ.Package() == "reflect" {
+			// FIXME
+			continue
+		}
+		s := region.Scan()
+		for s.Next() {
+			//
+		}
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -192,6 +218,8 @@ func TestReflect(t *testing.T) {
 			}
 
 			assertEqual(t, x, out)
+
+			assertCanInspect(t, b)
 		})
 	}
 }


### PR DESCRIPTION
This is the final PR in the introspection series (#107, #108, #109, #111, #112, #113), allowing users to scan objects within regions.

Each region encodes a primitive value, a compound array or struct, or a map. The scanner scans the tree using a preorder traversal, providing type information, primitive values (where applicable), access to functions/regions when references are encountered, and various other type-specific helpers to access information about an object. The scanner does not recurse when references to other regions are encountered. The user is responsible for following pointers (if desired) and keeping track of regions visited to prevent infinite loops when cycles are present in the object graph.

I fixed two inconsistencies in order to build the scanner:
* the root region now has a type of `interface{}`, since that's what `types.Serialize` actually serializes. Encoding this type (rather than the unboxed type) means we don't need a special case for the root region when scanning
* we now avoid double indirection when there's a reference to a map

<details>
<summary>Here's an example:</summary>

```go
c, err := types.Inspect(b)
if err != nil {
	panic(err)
}

regions := []*types.Region{c.Root()}
for i := 0; i < c.NumRegion(); i++ {
	regions = append(regions, c.Region(i))
}

for i, r := range regions {
	fmt.Println("Reading region", i, "with type", r.Type(), "and size", r.Size())

	s := r.Scan()
	for s.Next() {
		fmt.Println("=> reading from offset", s.Pos())
		if s.Custom() {
			fmt.Println("=> read an object serialized by a custom serializer")
		}

		switch s.Kind() {
		case reflect.Bool:
			fmt.Println("=> read bool", s.Bool())
		case reflect.Int:
			fmt.Println("=> read int", s.Int())
		case reflect.Int8:
			fmt.Println("=> read int", s.Int8())
		case reflect.Int16:
			fmt.Println("=> read int16", s.Int16())
		case reflect.Int32:
			fmt.Println("=> read int32", s.Int32())
		case reflect.Int64:
			fmt.Println("=> read int64", s.Int64())
		case reflect.Uint:
			fmt.Println("=> read uint", s.Uint())
		case reflect.Uint8:
			fmt.Println("=> read uint8", s.Uint8())
		case reflect.Uint16:
			fmt.Println("=> read uint16", s.Uint16())
		case reflect.Uint32:
			fmt.Println("=> read uint32", s.Uint32())
		case reflect.Uint64:
			fmt.Println("=> read uint64", s.Uint64())
		case reflect.Uintptr:
			fmt.Println("=> read uintptr", s.Uintptr())
		case reflect.Float32:
			fmt.Println("=> read float32", s.Float32())
		case reflect.Float64:
			fmt.Println("=> read float64", s.Float64())
		case reflect.Complex64:
			fmt.Println("=> read complex64", s.Complex64())
		case reflect.Complex128:
			fmt.Println("=> read complex128", s.Complex128())

		case reflect.Array:
			fmt.Println("=> read array of type", s.Type(), "with length", s.Len())

		case reflect.Interface:
			if s.Nil() {
				if t := s.Type(); t != nil {
					fmt.Println("=> read interface of type", t, "with nil value")
				} else {
					fmt.Println("=> read nil interface")
				}
			} else if r, off := s.Region(); r != nil {
				fmt.Println("=> read interface of type", s.Type(), "pointing to region", r, "offset", off)
			} else {
				fmt.Println("=> read interface of type", s.Type(), "with static data", s.Uint64())
			}

		case reflect.String:
			if s.Len() == 0 {
				fmt.Println("=> read string with length 0")
			} else {
				r, off := s.Region()
				fmt.Println("=> read string with length", s.Len(), "pointing to region", r, "offset", off)
			}

		case reflect.Slice:
			if r, off := s.Region(); r != nil {
				fmt.Println("=> read slice of type", s.Type(), "with length", s.Len(), "and cap", s.Cap(), "pointing to region", r, "offset", off)
			} else {
				fmt.Println("=> read nil slice of type", s.Type(), "with length", s.Len(), "and cap", s.Cap())
			}

		case reflect.Func:
			if s.Nil() {
				fmt.Println("=> read nil function with type", s.Type())
			} else if ct := s.Function().ClosureType(); ct != nil {
				fmt.Println("=> read function with type", s.Type(), "and closure layout", ct)
			} else {
				fmt.Println("=> read function with type", s.Type())
			}

		case reflect.Struct:
			fmt.Println("=> read struct of type", s.Type())

		case reflect.Pointer:
			if r, off := s.Region(); r != nil {
				fmt.Println("=> read pointer of type", s.Type(), "pointing to region", r, off)
			} else {
				fmt.Println("=> read nil pointer of type", s.Type())
			}

		case reflect.UnsafePointer:
			if r, off := s.Region(); r != nil {
				fmt.Println("=> read unsafe pointer pointing to region", r, "offset", off)
			} else {
				fmt.Println("=> read nil unsafe pointer")
			}

		default:
			panic(fmt.Sprintf("not implemented: %s", s.Kind()))
		}
	}
	if err := s.Close(); err != nil {
		panic(err)
	}
}
```

</details>