### PR TITLE
Fast path for bytes

### DIFF
--- a/types/serde_test.go
+++ b/types/serde_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
@@ -914,4 +915,22 @@ func assertRoundTrip[T any](t *testing.T, orig T) T {
 func testReflect(t *testing.T, name string, f func(t *testing.T)) {
 	t.Helper()
 	t.Run(name, f)
+}
+
+func BenchmarkRoundtripString(b *testing.B) {
+	s := strings.Repeat("x", 1000)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		buf, err := Serialize(s)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = Deserialize(buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
When serializing byte array regions, we were forking the serializer and passing each byte through the encoder, even though no encoding is necessary. This PR adds a fast path.

```
                   │  before.txt  │              after.txt              │
                   │    sec/op    │   sec/op     vs base                │
RoundtripString-32   31.039µ ± 1%   5.099µ ± 1%  -83.57% (p=0.000 n=10)

                   │  before.txt   │              after.txt               │
                   │     B/op      │     B/op      vs base                │
RoundtripString-32   11.109Ki ± 0%   7.922Ki ± 0%  -28.69% (p=0.000 n=10)

                   │ before.txt │             after.txt             │
                   │ allocs/op  │ allocs/op   vs base               │
RoundtripString-32   79.00 ± 0%   72.00 ± 0%  -8.86% (p=0.000 n=10)
```