### PR TITLE
Fix empty return with named results

### DIFF
--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -543,7 +543,7 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 	// assignments that use := to assignments that use =. Constant decls are
 	// hoisted and also have their value assigned in the function prologue.
 	decls, frameType, frameInit := extractDecls(p, typ, body, recv, defers, p.TypesInfo)
-	renameObjects(body, p.TypesInfo, decls, frameName, frameType, frameInit, scope)
+	renameObjects(typ, body, p.TypesInfo, decls, frameName, frameType, frameInit, scope)
 
 	// var _f{n} F = coroutine.Push[F](&_c.Stack)
 	gen.List = append(gen.List, &ast.DeclStmt{Decl: &ast.GenDecl{
@@ -633,7 +633,7 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 	gen.List = append(gen.List, compiledBody.List...)
 
 	// If the function returns one or more values, it must end with a return statement;
-	// we inject it if the function body does not already has one.
+	// we inject it if the function body does not already have one.
 	if typ.Results != nil && len(typ.Results.List) > 0 {
 		needsReturn := len(gen.List) == 0
 		if !needsReturn {

--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -632,8 +632,11 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 	compiledBody := compileDispatch(body, frameName, spans, mayYield).(*ast.BlockStmt)
 	gen.List = append(gen.List, compiledBody.List...)
 
-	// If the function returns one or more values, it must end with a return statement;
-	// we inject it if the function body does not already have one.
+	// If the function returns one or more values, it must end with a return
+	// statement. Since the input Go code is valid, the last entry in the
+	// dispatch table should already contain a return statement. We inject a
+	// panic at the end of the function in case this invariant does not hold
+	// anymore.
 	if typ.Results != nil && len(typ.Results.List) > 0 {
 		needsReturn := len(gen.List) == 0
 		if !needsReturn {
@@ -641,11 +644,23 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 			needsReturn = !endsWithReturn
 		}
 		if needsReturn {
-			gen.List = append(gen.List, &ast.ReturnStmt{})
+			gen.List = append(gen.List, &ast.ExprStmt{X: panicCall("unreachable")})
 		}
 	}
 
 	return gen
+}
+
+func panicCall(s string) ast.Expr {
+	return &ast.CallExpr{
+		Fun: &ast.Ident{Name: "panic"},
+		Args: []ast.Expr{
+			&ast.BasicLit{
+				Kind:  token.STRING,
+				Value: "\"" + s + "\"",
+			},
+		},
+	}
 }
 
 // This function returns true if a function body is composed of at most one

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -207,6 +207,13 @@ func TestCoroutineYield(t *testing.T) {
 			yields: []int{1, 2, 3, 2, 4, 6, 3, 6, 9, 2, 4, 6, 4, 8, 12, 6, 12, 18, 3, 6, 9, 6, 12, 18, 9, 18, 27},
 			result: 27,
 		},
+
+		{
+			name:   "return named values",
+			coroR:  func() int { return ReturnNamedValue() },
+			yields: []int{11},
+			result: 42,
+		},
 	}
 
 	// This emulates the installation of function type information by the

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -550,3 +550,10 @@ func varArgs(args ...int) {
 		coroutine.Yield[int, any](arg)
 	}
 }
+
+func ReturnNamedValue() (out int) {
+	out = 5
+	coroutine.Yield[int, any](11)
+	out = 42
+	return
+}

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3196,6 +3196,46 @@ func varArgs(_fn0 ...int) {
 		}
 	}
 }
+
+//go:noinline
+func ReturnNamedValue() (_fn0 int) {
+	_c := coroutine.LoadContext[int, any]()
+	var _f0 *struct {
+		IP int
+		X0 int
+	} = coroutine.Push[struct {
+		IP int
+		X0 int
+	}](&_c.Stack)
+	if _f0.IP == 0 {
+		*_f0 = struct {
+			IP int
+			X0 int
+		}{}
+	}
+	defer func() {
+		if !_c.Unwinding() {
+			coroutine.Pop(&_c.Stack)
+		}
+	}()
+	switch {
+	case _f0.IP < 2:
+		_f0.X0 = 5
+		_f0.IP = 2
+		fallthrough
+	case _f0.IP < 3:
+		coroutine.Yield[int, any](11)
+		_f0.IP = 3
+		fallthrough
+	case _f0.IP < 4:
+		_f0.X0 = 42
+		_f0.IP = 4
+		fallthrough
+	case _f0.IP < 5:
+		return _f0.X0
+	}
+	return
+}
 func init() {
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.EvenSquareGenerator")
@@ -3292,6 +3332,7 @@ func init() {
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.RangeTripleFuncValue")
 	_types.RegisterFunc[func(i int)]("github.com/stealthrocket/coroutine/compiler/testdata.RangeTripleFuncValue.func2")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.RangeYieldAndDeferAssign")
+	_types.RegisterFunc[func() (_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.ReturnNamedValue")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.Select")
 	_types.RegisterFunc[func(_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.Shadowing")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.SomeFunctionThatShouldExistInTheCompiledFile")

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -245,7 +245,7 @@ func NestedLoops(_fn0 int) (_ int) {
 
 		return _f0.X1
 	}
-	return
+	panic("unreachable")
 }
 
 //go:noinline
@@ -1616,7 +1616,7 @@ func Range10ClosureCapturingValues() {
 
 				return false
 			}
-			return
+			panic("unreachable")
 		}
 		_f1.IP = 4
 		fallthrough
@@ -1733,7 +1733,7 @@ func Range10ClosureCapturingPointers() {
 
 				return false
 			}
-			return
+			panic("unreachable")
 		}
 		_f1.IP = 5
 		fallthrough
@@ -1953,7 +1953,7 @@ func Range10ClosureHeterogenousCapture() {
 			case _f0.IP < 16:
 				return _f1.X10 < 10
 			}
-			return
+			panic("unreachable")
 		}
 		_f1.IP = 13
 		fallthrough
@@ -2837,7 +2837,7 @@ func a(_fn0 int) (_ int) {
 	case _f0.IP < 3:
 		return _f0.X0
 	}
-	return
+	panic("unreachable")
 }
 
 //go:noinline
@@ -2869,7 +2869,7 @@ func b(_fn0 int) (_ int) {
 	case _f0.IP < 3:
 		return _f0.X0
 	}
-	return
+	panic("unreachable")
 }
 
 //go:noinline
@@ -3234,7 +3234,7 @@ func ReturnNamedValue() (_fn0 int) {
 	case _f0.IP < 5:
 		return _f0.X0
 	}
-	return
+	panic("unreachable")
 }
 func init() {
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")


### PR DESCRIPTION
When a function has named results and uses empty return, the named result would correctly be renamed and hoisted into the frame struct. In that scenario, using an explicit return (such as "return myvalue") works, because the renaming pass goes over the expression in the return statement and replaces the named result with a selector into the frame struct.

However, when using an empty return (just "return"), the named result is not in the AST, and the renaming pass would not see it.

This patch add and final pass to the renaming procedure to change empty returns in functions with named results into explicit returns using selectors into the frame struct. For example:

    func example() (out int) {
        out = 42
        return
    }

gets rewritten into:

    func example() (_fn0 int) {
        var _f0 *struct {
            IP int
            X0 int
        }
        _f0.X0 = 42
        return _f0.X0
    }

(other transformations omitted for this example)