### PR TITLE
coroc: don't register type information for functions with type parameters

### DIFF
--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -220,6 +220,18 @@ func TestCoroutineYield(t *testing.T) {
 			coro:   func() { IdentityGeneric[int](11) },
 			yields: []int{11},
 		},
+
+		{
+			name:   "identity generic (2)",
+			coro:   func() { IdentityGenericInt(11) },
+			yields: []int{11},
+		},
+
+		{
+			name:   "identity generic (3)",
+			coro:   func() { IdentityGenericStructInt(11) },
+			yields: []int{11},
+		},
 	}
 
 	// This emulates the installation of function type information by the

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -214,6 +214,12 @@ func TestCoroutineYield(t *testing.T) {
 			yields: []int{11},
 			result: 42,
 		},
+
+		{
+			name:   "identity generic",
+			coro:   func() { IdentityGeneric[int](11) },
+			yields: []int{11},
+		},
 	}
 
 	// This emulates the installation of function type information by the

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -218,7 +218,7 @@ func (c *compiler) generateFunctypes(p *packages.Package, f *ast.File, colors ma
 			fn := c.prog.FuncValue(obj)
 			if fn.TypeParams() != nil {
 				// TODO: support generics. Generate type func/closure type information for each instance from: instances := c.generics[fn]
-				log.Printf("warning: cannot register runtime type information for generic function %s", d.Name)
+				log.Printf("warning: cannot register runtime type information for generic function %s", fn)
 				continue
 			} else {
 				scope := &funcscope{vars: map[string]*funcvar{}}

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -217,6 +217,7 @@ func (c *compiler) generateFunctypes(p *packages.Package, f *ast.File, colors ma
 			obj := p.TypesInfo.ObjectOf(d.Name).(*types.Func)
 			fn := c.prog.FuncValue(obj)
 			if fn.TypeParams() != nil {
+				// TODO: support generics. Generate type func/closure type information for each instance from: instances := c.generics[fn]
 				log.Printf("warning: cannot register runtime type information for generic function %s", d.Name)
 				continue
 			} else {

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -561,3 +561,19 @@ func ReturnNamedValue() (out int) {
 func IdentityGeneric[T any](n T) {
 	coroutine.Yield[T, any](n)
 }
+
+type IdentityGenericStruct[T any] struct {
+	n T
+}
+
+func (i *IdentityGenericStruct[T]) Run() {
+	coroutine.Yield[T, any](i.n)
+}
+
+func IdentityGenericInt(n int) {
+	IdentityGeneric[int](n)
+}
+
+func IdentityGenericStructInt(n int) {
+	(&IdentityGenericStruct[int]{n: n}).Run()
+}

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -557,3 +557,7 @@ func ReturnNamedValue() (out int) {
 	out = 42
 	return
 }
+
+func IdentityGeneric[T any](n T) {
+	coroutine.Yield[T, any](n)
+}

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3239,12 +3239,27 @@ func ReturnNamedValue() (_fn0 int) {
 
 //go:noinline
 func IdentityGeneric[T any](n T) { coroutine.Yield[T, any](n) }
+
+type IdentityGenericStruct[T any] struct {
+	n T
+}
+
+//go:noinline
+func (i *IdentityGenericStruct[T]) Run() { coroutine.Yield[T, any](i.n) }
+
+//go:noinline
+func IdentityGenericInt(n int) { IdentityGeneric[int](n) }
+
+//go:noinline
+func IdentityGenericStructInt(n int) { (&IdentityGenericStruct[int]{n: n}).Run() }
 func init() {
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.EvenSquareGenerator")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.FizzBuzzIfGenerator")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.FizzBuzzSwitchGenerator")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Identity")
+	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericInt")
+	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericStructInt")
 	_types.RegisterFunc[func(_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.LoopBreakAndContinue")
 	_types.RegisterFunc[func(_fn1 int)]("github.com/stealthrocket/coroutine/compiler/testdata.MethodGenerator")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.NestedLoops")

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3236,6 +3236,9 @@ func ReturnNamedValue() (_fn0 int) {
 	}
 	panic("unreachable")
 }
+
+//go:noinline
+func IdentityGeneric[T any](n T) { coroutine.Yield[T, any](n) }
 func init() {
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.EvenSquareGenerator")

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -92,6 +92,12 @@ func typeExpr(p *packages.Package, typ types.Type) ast.Expr {
 			c.Dir = ast.RECV
 		}
 		return c
+
+	case *types.TypeParam:
+		obj := t.Obj()
+		ident := ast.NewIdent(obj.Name())
+		p.TypesInfo.Defs[ident] = obj
+		return ident
 	}
 	panic(fmt.Sprintf("not implemented: %T", typ))
 }

--- a/types/types.go
+++ b/types/types.go
@@ -399,6 +399,9 @@ func (m *funcmap) RegisterAddr(addr unsafe.Pointer) (id funcid, closureType refl
 	if f == nil {
 		panic(fmt.Sprintf("function not found at address %v", addr))
 	}
+	if f.Type == nil {
+		panic(fmt.Sprintf("type information not registered for function %s (%p)", f.Name, addr))
+	}
 
 	var closureTypeID typeid
 	if f.Closure != nil {


### PR DESCRIPTION
This partially fixes https://github.com/stealthrocket/coroutine/issues/123. 

This PR updates the compiler to ignore generic functions when registering type information for the runtime and its serialization layer (via `types.RegisterFunc` and `types.RegisterClosure`).

This expands the range of Go programs with generics that are supported. If the input program never serializes a reference to a generic function or a closure created within a generic function, the compiler output is valid. For cases where the input attempts to serialize a generic function or nested closure, a runtime check has been implemented. This check triggers a panic if type information is unavailable for the particular function.