### PR TITLE
coroc: support generics

### DIFF
--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -435,7 +435,7 @@ func (scope *scope) compileFuncDecl(p *packages.Package, fn *ast.FuncDecl, color
 	// Generate the coroutine function. At this stage, use the same name
 	// as the source function (and require that the caller use build tags
 	// to disambiguate function calls).
-	fnType := funcTypeWithNamedResults(fn.Type)
+	fnType := funcTypeWithNamedResults(p, fn)
 	gen := &ast.FuncDecl{
 		Recv: fn.Recv,
 		Doc:  &ast.CommentGroup{},
@@ -473,7 +473,7 @@ func (scope *scope) compileFuncLit(p *packages.Package, fn *ast.FuncLit, color *
 	log.Printf("compiling function literal %s", p.Name)
 
 	gen := &ast.FuncLit{
-		Type: funcTypeWithNamedResults(fn.Type),
+		Type: funcTypeWithNamedResults(p, fn),
 		Body: scope.compileFuncBody(p, fn.Type, fn.Body, nil, color),
 	}
 
@@ -710,21 +710,42 @@ func isExpr(body *ast.BlockStmt) bool {
 	return false
 }
 
-func funcTypeWithNamedResults(t *ast.FuncType) *ast.FuncType {
+func funcTypeWithNamedResults(p *packages.Package, n ast.Node) *ast.FuncType {
+	t := functionTypeOf(n)
+	signature := functionSignatureOf(p, n)
+	if signature == nil {
+		panic("missing type info for func decl or lit")
+	}
 	if t.Results == nil {
 		return t
 	}
-	underscore := ast.NewIdent("_")
 	funcType := *t
 	funcType.Results = &ast.FieldList{
 		List: slices.Clone(t.Results.List),
 	}
+	resultTypes := signature.Results()
+	if resultTypes == nil || resultTypes.Len() == 0 {
+		panic("result type count mismatch")
+	}
+	typePos := 0
 	for i, f := range t.Results.List {
-		if len(f.Names) == 0 {
-			field := *f
-			field.Names = []*ast.Ident{underscore}
-			funcType.Results.List[i] = &field
+		if len(f.Names) > 0 {
+			typePos += len(f.Names)
+			continue
 		}
+		if typePos >= resultTypes.Len() {
+			panic("result type count mismatch")
+		}
+		t := resultTypes.At(typePos)
+		underscore := ast.NewIdent("_")
+		p.TypesInfo.Defs[underscore] = t
+		field := *f
+		field.Names = []*ast.Ident{underscore}
+		funcType.Results.List[i] = &field
+		typePos++
+	}
+	if typePos != resultTypes.Len() {
+		panic("result type count mismatch")
 	}
 	return &funcType
 }

--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -534,8 +534,8 @@ func (scope *scope) compileFuncBody(p *packages.Package, typ *ast.FuncType, body
 	ctx := ast.NewIdent("_c")
 
 	yieldTypeExpr := make([]ast.Expr, 2)
-	yieldTypeExpr[0] = typeExpr(p, color.Params().At(0).Type())
-	yieldTypeExpr[1] = typeExpr(p, color.Results().At(0).Type())
+	yieldTypeExpr[0] = typeExpr(p, color.Params().At(0).Type(), nil)
+	yieldTypeExpr[1] = typeExpr(p, color.Results().At(0).Type(), nil)
 
 	coroutineIdent := ast.NewIdent("coroutine")
 	p.TypesInfo.Uses[coroutineIdent] = types.NewPkgName(token.NoPos, p.Types, "coroutine", scope.compiler.coroutinePkg.Types)

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -216,27 +216,27 @@ func TestCoroutineYield(t *testing.T) {
 		},
 
 		{
-			name:   "identity generic",
-			coro:   func() { IdentityGeneric[int](11) },
-			yields: []int{11},
-		},
-
-		{
-			name:   "identity generic (2)",
+			name:   "generic function",
 			coro:   func() { IdentityGenericInt(11) },
 			yields: []int{11},
 		},
 
 		{
-			name:   "identity generic (3)",
+			name:   "generic struct",
 			coro:   func() { IdentityGenericStructInt(11) },
 			yields: []int{11},
 		},
 
 		{
-			name:   "identity generic (4)",
+			name:   "generic function closure",
 			coro:   func() { IdentityGenericClosureInt(11) },
 			yields: []int{11, 11},
+		},
+
+		{
+			name:   "generic struct closure",
+			coro:   func() { IdentityGenericStructClosureInt(11) },
+			yields: []int{11, 100, 11, 100},
 		},
 	}
 

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -236,7 +236,7 @@ func TestCoroutineYield(t *testing.T) {
 		{
 			name:   "generic struct closure",
 			coro:   func() { IdentityGenericStructClosureInt(11) },
-			yields: []int{11, 100, 11, 100},
+			yields: []int{11, 100, 23, 12, 101, 45},
 		},
 	}
 

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -232,6 +232,12 @@ func TestCoroutineYield(t *testing.T) {
 			coro:   func() { IdentityGenericStructInt(11) },
 			yields: []int{11},
 		},
+
+		{
+			name:   "identity generic (4)",
+			coro:   func() { IdentityGenericClosureInt(11) },
+			yields: []int{11, 11},
+		},
 	}
 
 	// This emulates the installation of function type information by the

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -236,7 +236,7 @@ func TestCoroutineYield(t *testing.T) {
 		{
 			name:   "generic struct closure",
 			coro:   func() { IdentityGenericStructClosureInt(11) },
-			yields: []int{11, 100, 23, 12, 101, 45},
+			yields: []int{-1, 11, 100, 23, 12, 101, 45},
 		},
 	}
 

--- a/compiler/decls.go
+++ b/compiler/decls.go
@@ -96,7 +96,7 @@ func extractDecls(p *packages.Package, typ *ast.FuncType, body *ast.BlockStmt, r
 			} else {
 				for _, spec := range n.Specs {
 					valueSpec := spec.(*ast.ValueSpec)
-					valueType := typeExpr(p, info.TypeOf(valueSpec.Names[0]))
+					valueType := typeExpr(p, info.TypeOf(valueSpec.Names[0]), nil)
 					for _, ident := range valueSpec.Names {
 						if ident.Name != "_" {
 							frameType.Fields.List = append(frameType.Fields.List, &ast.Field{
@@ -132,7 +132,7 @@ func extractDecls(p *packages.Package, typ *ast.FuncType, body *ast.BlockStmt, r
 				}
 				frameType.Fields.List = append(frameType.Fields.List, &ast.Field{
 					Names: []*ast.Ident{name},
-					Type:  typeExpr(p, t),
+					Type:  typeExpr(p, t, nil),
 				})
 			}
 		}

--- a/compiler/desugar.go
+++ b/compiler/desugar.go
@@ -314,7 +314,7 @@ func (d *desugarer) desugar(stmt ast.Stmt, breakTo, continueTo, userLabel *ast.I
 							&ast.CallExpr{
 								Fun: d.builtin("make"),
 								Args: []ast.Expr{
-									typeExpr(d.pkg, keySliceType),
+									typeExpr(d.pkg, keySliceType, nil),
 									&ast.BasicLit{Kind: token.INT, Value: "0"},
 									&ast.CallExpr{Fun: d.builtin("len"), Args: []ast.Expr{x}},
 								},
@@ -476,7 +476,7 @@ func (d *desugarer) desugar(stmt ast.Stmt, breakTo, continueTo, userLabel *ast.I
 							Specs: []ast.Spec{
 								&ast.ValueSpec{
 									Names: []*ast.Ident{tmpLhs},
-									Type:  typeExpr(d.pkg, lhsType),
+									Type:  typeExpr(d.pkg, lhsType, nil),
 								},
 							},
 						}})

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -172,10 +172,18 @@ func collectFunctypes(p *packages.Package, name string, fn ast.Node, scope *func
 		signature: signature,
 	}
 	if len(freeVars) > 0 {
-		fields := make([]*ast.Field, 1+len(freeVars))
-		fields[0] = &ast.Field{
-			Type:  ast.NewIdent("uintptr"),
-			Names: []*ast.Ident{ast.NewIdent("F")},
+		fields := []*ast.Field{
+			{
+				Type:  ast.NewIdent("uintptr"),
+				Names: []*ast.Ident{ast.NewIdent("F")},
+			},
+		}
+		if g != nil {
+			// Append a field for the dictionary.
+			fields = append(fields, &ast.Field{
+				Type:  ast.NewIdent("uintptr"),
+				Names: []*ast.Ident{ast.NewIdent("D")},
+			})
 		}
 		for i, freeVar := range freeVars {
 			fieldName := ast.NewIdent(fmt.Sprintf("X%d", i))
@@ -191,10 +199,10 @@ func collectFunctypes(p *packages.Package, name string, fn ast.Node, scope *func
 			// and pointers will be less than 128 bytes on all platforms, which
 			// means that the stack frame pointer is always captured by value.
 
-			fields[i+1] = &ast.Field{
+			fields = append(fields, &ast.Field{
 				Type:  fieldType,
 				Names: []*ast.Ident{fieldName},
-			}
+			})
 		}
 		functype.closure = &ast.StructType{
 			Fields: &ast.FieldList{List: fields},

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -83,7 +83,9 @@ func collectFunctypes(p *packages.Package, name string, fn ast.Node, scope *func
 		return v
 	}
 
-	signature := functionTypeOf(fn)
+	signature := copyFunctionType(functionTypeOf(fn))
+	signature.TypeParams = nil
+
 	for _, fields := range []*ast.FieldList{signature.Params, signature.Results} {
 		if fields != nil {
 			for _, field := range fields.List {
@@ -106,7 +108,6 @@ func collectFunctypes(p *packages.Package, name string, fn ast.Node, scope *func
 			}
 		}
 	}
-	signature.TypeParams = nil
 
 	var inspect func(ast.Node) bool
 	inspect = func(node ast.Node) bool {
@@ -332,6 +333,30 @@ func functionTypeOf(fn ast.Node) *ast.FuncType {
 	default:
 		panic("node is neither *ast.FuncDecl or *ast.FuncLit")
 	}
+}
+
+func copyFunctionType(f *ast.FuncType) *ast.FuncType {
+	return &ast.FuncType{
+		TypeParams: copyFieldList(f.TypeParams),
+		Params:     copyFieldList(f.Params),
+		Results:    copyFieldList(f.Results),
+	}
+}
+
+func copyFieldList(f *ast.FieldList) *ast.FieldList {
+	if f == nil {
+		return nil
+	}
+	list := make([]*ast.Field, len(f.List))
+	for i := range f.List {
+		list[i] = copyField(f.List[i])
+	}
+	return &ast.FieldList{List: list}
+}
+
+func copyField(f *ast.Field) *ast.Field {
+	c := *f
+	return &c
 }
 
 func functionBodyOf(fn ast.Node) *ast.BlockStmt {

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -178,13 +178,6 @@ func collectFunctypes(p *packages.Package, name string, fn ast.Node, scope *func
 				Names: []*ast.Ident{ast.NewIdent("F")},
 			},
 		}
-		if g != nil {
-			// Append a field for the dictionary.
-			fields = append(fields, &ast.Field{
-				Type:  ast.NewIdent("uintptr"),
-				Names: []*ast.Ident{ast.NewIdent("D")},
-			})
-		}
 		for i, freeVar := range freeVars {
 			fieldName := ast.NewIdent(fmt.Sprintf("X%d", i))
 			fieldType := freeVar.typ
@@ -202,6 +195,13 @@ func collectFunctypes(p *packages.Package, name string, fn ast.Node, scope *func
 			fields = append(fields, &ast.Field{
 				Type:  fieldType,
 				Names: []*ast.Ident{fieldName},
+			})
+		}
+		if g != nil {
+			// Append a field for the dictionary.
+			fields = append(fields, &ast.Field{
+				Type:  ast.NewIdent("uintptr"),
+				Names: []*ast.Ident{ast.NewIdent("D")},
 			})
 		}
 		functype.closure = &ast.StructType{

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -86,7 +86,8 @@ func collectFunctypes(p *packages.Package, name string, fn ast.Node, scope *func
 	signature := copyFunctionType(functionTypeOf(fn))
 	signature.TypeParams = nil
 
-	for _, fields := range []*ast.FieldList{signature.Params, signature.Results} {
+	recv := copyFieldList(functionRecvOf(fn))
+	for _, fields := range []*ast.FieldList{recv, signature.Params, signature.Results} {
 		if fields != nil {
 			for _, field := range fields.List {
 				for _, name := range field.Names {
@@ -343,6 +344,17 @@ func functionTypeOf(fn ast.Node) *ast.FuncType {
 		return f.Type
 	case *ast.FuncLit:
 		return f.Type
+	default:
+		panic("node is neither *ast.FuncDecl or *ast.FuncLit")
+	}
+}
+
+func functionRecvOf(fn ast.Node) *ast.FieldList {
+	switch f := fn.(type) {
+	case *ast.FuncDecl:
+		return f.Recv
+	case *ast.FuncLit:
+		return nil
 	default:
 		panic("node is neither *ast.FuncDecl or *ast.FuncLit")
 	}

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -375,6 +375,17 @@ func functionTypeOf(fn ast.Node) *ast.FuncType {
 	}
 }
 
+func functionSignatureOf(p *packages.Package, fn ast.Node) *types.Signature {
+	switch f := fn.(type) {
+	case *ast.FuncDecl:
+		return p.TypesInfo.Defs[f.Name].Type().(*types.Signature)
+	case *ast.FuncLit:
+		return p.TypesInfo.TypeOf(f).(*types.Signature)
+	default:
+		panic("node is neither *ast.FuncDecl or *ast.FuncLit")
+	}
+}
+
 func functionRecvOf(fn ast.Node) *ast.FieldList {
 	switch f := fn.(type) {
 	case *ast.FuncDecl:

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -265,7 +265,7 @@ func (c *compiler) generateFunctypes(p *packages.Package, f *ast.File, colors ma
 					}
 					scope := &funcscope{vars: map[string]*funcvar{}}
 					name := g.gcshapePath()
-					collectFunctypes(p, name, instance.Syntax(), scope, colors, functypes, g)
+					collectFunctypes(p, name, d, scope, colors, functypes, g)
 				}
 			} else {
 				scope := &funcscope{vars: map[string]*funcvar{}}

--- a/compiler/function.go
+++ b/compiler/function.go
@@ -461,7 +461,7 @@ func (g *genericInstance) partial() bool {
 }
 
 func (g *genericInstance) scanRecvTypeArgs(fn func(*types.TypeParam, int, types.Type)) {
-	typeParams := g.recvType.TypeParams()
+	typeParams := g.instance.Signature.RecvTypeParams()
 	typeArgs := g.recvType.TypeArgs()
 	for i := 0; i < typeArgs.Len(); i++ {
 		arg := typeArgs.At(i)
@@ -583,6 +583,9 @@ func writeGoShape(b *strings.Builder, tt types.Type) {
 	switch t := tt.Underlying().(type) {
 	case *types.Basic:
 		b.WriteString(t.Name())
+	case *types.Pointer:
+		// All pointers resolve to *uint8.
+		b.WriteString("*uint8")
 	case *types.Interface:
 		if t.Empty() {
 			b.WriteString("interface{}")

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -562,20 +562,8 @@ func IdentityGeneric[T any](n T) {
 	coroutine.Yield[T, any](n)
 }
 
-type IdentityGenericStruct[T any] struct {
-	n T
-}
-
-func (i *IdentityGenericStruct[T]) Run() {
-	coroutine.Yield[T, any](i.n)
-}
-
 func IdentityGenericInt(n int) {
 	IdentityGeneric[int](n)
-}
-
-func IdentityGenericStructInt(n int) {
-	(&IdentityGenericStruct[int]{n: n}).Run()
 }
 
 func IdentityGenericClosure[T any](n T) {
@@ -595,4 +583,30 @@ func buildClosure[T any](n T) func() {
 
 func IdentityGenericClosureInt(n int) {
 	IdentityGenericClosure[int](n)
+}
+
+type IdentityGenericStruct[T any] struct {
+	n T
+}
+
+func (i *IdentityGenericStruct[T]) Run() {
+	coroutine.Yield[T, any](i.n)
+}
+
+//go:noinline
+func (i *IdentityGenericStruct[T]) Closure(n T) func() {
+	return func() {
+		coroutine.Yield[T, any](i.n)
+		coroutine.Yield[T, any](n)
+	}
+}
+
+func IdentityGenericStructInt(n int) {
+	(&IdentityGenericStruct[int]{n: n}).Run()
+}
+
+func IdentityGenericStructClosureInt(n int) {
+	fn := (&IdentityGenericStruct[int]{n: n}).Closure(100)
+	fn()
+	fn()
 }

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -597,8 +597,10 @@ func (i *IdentityGenericStruct[T]) Run() {
 	coroutine.Yield[T, any](i.n)
 }
 
-//go:noinline
 func (i *IdentityGenericStruct[T]) Closure(n T) func(T) {
+	// Force compilation of this method. Remove once #84 is fixed.
+	coroutine.Yield[T, any](-1)
+
 	return func(x T) {
 		coroutine.Yield[T, any](i.n)
 		i.n++

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -585,7 +585,11 @@ func IdentityGenericClosureInt(n int) {
 	IdentityGenericClosure[int](n)
 }
 
-type IdentityGenericStruct[T any] struct {
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+type IdentityGenericStruct[T integer] struct {
 	n T
 }
 
@@ -594,10 +598,13 @@ func (i *IdentityGenericStruct[T]) Run() {
 }
 
 //go:noinline
-func (i *IdentityGenericStruct[T]) Closure(n T) func() {
-	return func() {
+func (i *IdentityGenericStruct[T]) Closure(n T) func(T) {
+	return func(x T) {
 		coroutine.Yield[T, any](i.n)
+		i.n++
 		coroutine.Yield[T, any](n)
+		n++
+		coroutine.Yield[T, any](x)
 	}
 }
 
@@ -607,6 +614,6 @@ func IdentityGenericStructInt(n int) {
 
 func IdentityGenericStructClosureInt(n int) {
 	fn := (&IdentityGenericStruct[int]{n: n}).Closure(100)
-	fn()
-	fn()
+	fn(23)
+	fn(45)
 }

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -577,3 +577,22 @@ func IdentityGenericInt(n int) {
 func IdentityGenericStructInt(n int) {
 	(&IdentityGenericStruct[int]{n: n}).Run()
 }
+
+func IdentityGenericClosure[T any](n T) {
+	fn := buildClosure(n)
+	fn()
+	fn()
+}
+
+// TODO: add this go:noinline directive automatically
+//
+//go:noinline
+func buildClosure[T any](n T) func() {
+	return func() {
+		coroutine.Yield[T, any](n)
+	}
+}
+
+func IdentityGenericClosureInt(n int) {
+	IdentityGenericClosure[int](n)
+}

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -584,7 +584,7 @@ func IdentityGenericClosure[T any](n T) {
 	fn()
 }
 
-// TODO: add this go:noinline directive automatically
+// TODO: add this go:noinline directive automatically (once stealthrocket/coroutine#84 is fixed)
 //
 //go:noinline
 func buildClosure[T any](n T) func() {

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3238,7 +3238,7 @@ func ReturnNamedValue() (_fn0 int) {
 }
 
 //go:noinline
-func IdentityGeneric(n int) { coroutine.Yield[T, any](n) }
+func IdentityGeneric[T any](n T) { coroutine.Yield[T, any](n) }
 
 type IdentityGenericStruct[T any] struct {
 	n T
@@ -3254,8 +3254,8 @@ func IdentityGenericInt(n int) { IdentityGeneric[int](n) }
 func IdentityGenericStructInt(n int) { (&IdentityGenericStruct[int]{n: n}).Run() }
 
 //go:noinline
-func IdentityGenericClosure(_fn0 int) {
-	_c := coroutine.LoadContext[int, any]()
+func IdentityGenericClosure[T any](_fn0 T) {
+	_c := coroutine.LoadContext[T, any]()
 	var _f0 *struct {
 		IP int
 		X0 T
@@ -3294,7 +3294,7 @@ func IdentityGenericClosure(_fn0 int) {
 // TODO: add this go:noinline directive automatically
 //
 //go:noinline
-func buildClosure(n T) func() {
+func buildClosure[T any](n T) func() {
 	return func() {
 		coroutine.Yield[T, any](n)
 	}
@@ -3438,7 +3438,7 @@ func init() {
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.YieldingExpressionDesugaring")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.a")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.b")
-	_types.RegisterFunc[func(n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int]")
+	_types.RegisterFunc[func(n int) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int]")
 	_types.RegisterClosure[func(), struct {
 		F  uintptr
 		X0 int

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3252,12 +3252,63 @@ func IdentityGenericInt(n int) { IdentityGeneric[int](n) }
 
 //go:noinline
 func IdentityGenericStructInt(n int) { (&IdentityGenericStruct[int]{n: n}).Run() }
+
+//go:noinline
+func IdentityGenericClosure[T any](_fn0 T) {
+	_c := coroutine.LoadContext[int, any]()
+	var _f0 *struct {
+		IP int
+		X0 T
+		X1 func()
+	} = coroutine.Push[struct {
+		IP int
+		X0 T
+		X1 func()
+	}](&_c.Stack)
+	if _f0.IP == 0 {
+		*_f0 = struct {
+			IP int
+			X0 T
+			X1 func()
+		}{X0: _fn0}
+	}
+	defer func() {
+		if !_c.Unwinding() {
+			coroutine.Pop(&_c.Stack)
+		}
+	}()
+	switch {
+	case _f0.IP < 2:
+		_f0.X1 = buildClosure(_f0.X0)
+		_f0.IP = 2
+		fallthrough
+	case _f0.IP < 3:
+		_f0.X1()
+		_f0.IP = 3
+		fallthrough
+	case _f0.IP < 4:
+		_f0.X1()
+	}
+}
+
+// TODO: add this go:noinline directive automatically
+//
+//go:noinline
+func buildClosure[T any](n T) func() {
+	return func() {
+		coroutine.Yield[T, any](n)
+	}
+}
+
+//go:noinline
+func IdentityGenericClosureInt(n int) { IdentityGenericClosure[int](n) }
 func init() {
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.EvenSquareGenerator")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.FizzBuzzIfGenerator")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.FizzBuzzSwitchGenerator")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Identity")
+	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericClosureInt")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericInt")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericStructInt")
 	_types.RegisterFunc[func(_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.LoopBreakAndContinue")

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3574,12 +3574,12 @@ func init() {
 	_types.RegisterFunc[func(_fn1 int) (_ func(int))]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure")
 	_types.RegisterClosure[func(_fn0 int), struct {
 		F  uintptr
-		D  uintptr
 		X0 *struct {
 			IP int
 			X0 *IdentityGenericStruct[int]
 			X1 int
 		}
+		D uintptr
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure.func2")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Run")
 	_types.RegisterFunc[func(_fn1 int)]("github.com/stealthrocket/coroutine/compiler/testdata.(*MethodGeneratorState).MethodGenerator")
@@ -3721,8 +3721,8 @@ func init() {
 	_types.RegisterFunc[func(n int) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int]")
 	_types.RegisterClosure[func(), struct {
 		F  uintptr
-		D  uintptr
 		X0 int
+		D  uintptr
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int].func1")
 	_types.RegisterFunc[func(_fn0 ...int)]("github.com/stealthrocket/coroutine/compiler/testdata.varArgs")
 }

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3255,7 +3255,7 @@ func IdentityGenericStructInt(n int) { (&IdentityGenericStruct[int]{n: n}).Run()
 
 //go:noinline
 func IdentityGenericClosure[T any](_fn0 T) {
-	_c := coroutine.LoadContext[int, any]()
+	_c := coroutine.LoadContext[T, any]()
 	var _f0 *struct {
 		IP int
 		X0 T
@@ -3441,6 +3441,7 @@ func init() {
 	_types.RegisterFunc[func(n int) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int]")
 	_types.RegisterClosure[func(), struct {
 		F  uintptr
+		D  uintptr
 		X0 int
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int].func1")
 	_types.RegisterFunc[func(_fn0 ...int)]("github.com/stealthrocket/coroutine/compiler/testdata.varArgs")

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3305,14 +3305,81 @@ type IdentityGenericStruct[T integer] struct {
 func (i *IdentityGenericStruct[T]) Run() { coroutine.Yield[T, any](i.n) }
 
 //go:noinline
-func (i *IdentityGenericStruct[T]) Closure(n T) func(T) {
-	return func(x T) {
-		coroutine.Yield[T, any](i.n)
-		i.n++
-		coroutine.Yield[T, any](n)
-		n++
-		coroutine.Yield[T, any](x)
+func (_fn0 *IdentityGenericStruct[T]) Closure(_fn1 T) (_ func(T)) {
+	_c := coroutine.LoadContext[int, any]()
+	var _f1 *struct {
+		IP int
+		X0 *IdentityGenericStruct[T]
+		X1 T
+	} = coroutine.Push[struct {
+		IP int
+		X0 *IdentityGenericStruct[T]
+		X1 T
+	}](&_c.Stack)
+	if _f1.IP == 0 {
+		*_f1 = struct {
+			IP int
+			X0 *IdentityGenericStruct[T]
+			X1 T
+		}{X0: _fn0, X1: _fn1}
 	}
+	defer func() {
+		if !_c.Unwinding() {
+			coroutine.Pop(&_c.Stack)
+		}
+	}()
+	switch {
+	case _f1.IP < 2:
+
+		coroutine.Yield[T, any](-1)
+		_f1.IP = 2
+		fallthrough
+	case _f1.IP < 3:
+
+		return func(_fn0 T) {
+			_c := coroutine.LoadContext[int, any]()
+			var _f0 *struct {
+				IP int
+				X0 T
+			} = coroutine.Push[struct {
+				IP int
+				X0 T
+			}](&_c.Stack)
+			if _f0.IP == 0 {
+				*_f0 = struct {
+					IP int
+					X0 T
+				}{X0: _fn0}
+			}
+			defer func() {
+				if !_c.Unwinding() {
+					coroutine.Pop(&_c.Stack)
+				}
+			}()
+			switch {
+			case _f0.IP < 2:
+				coroutine.Yield[T, any](_f1.X0.n)
+				_f0.IP = 2
+				fallthrough
+			case _f0.IP < 3:
+				_f1.X0.
+					n++
+				_f0.IP = 3
+				fallthrough
+			case _f0.IP < 4:
+				coroutine.Yield[T, any](_f1.X1)
+				_f0.IP = 4
+				fallthrough
+			case _f0.IP < 5:
+				_f1.X1++
+				_f0.IP = 5
+				fallthrough
+			case _f0.IP < 6:
+				coroutine.Yield[T, any](_f0.X0)
+			}
+		}
+	}
+	panic("unreachable")
 }
 
 //go:noinline
@@ -3356,13 +3423,16 @@ func IdentityGenericStructClosureInt(_fn0 int) {
 	}
 }
 func init() {
-	_types.RegisterFunc[func(n int) func(T)]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure")
-	_types.RegisterClosure[func(x int), struct {
+	_types.RegisterFunc[func(_fn1 int) (_ func(T))]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure")
+	_types.RegisterClosure[func(_fn0 int), struct {
 		F  uintptr
 		D  uintptr
-		X0 *IdentityGenericStruct[T]
-		X1 int
-	}]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure.func1")
+		X0 *struct {
+			IP int
+			X0 *IdentityGenericStruct[T]
+			X1 T
+		}
+	}]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure.func2")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Run")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.EvenSquareGenerator")

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3255,7 +3255,7 @@ func IdentityGenericStructInt(n int) { (&IdentityGenericStruct[int]{n: n}).Run()
 
 //go:noinline
 func IdentityGenericClosure[T any](_fn0 T) {
-	_c := coroutine.LoadContext[T, any]()
+	_c := coroutine.LoadContext[int, any]()
 	var _f0 *struct {
 		IP int
 		X0 T
@@ -3443,10 +3443,5 @@ func init() {
 		F  uintptr
 		X0 int
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int].func1")
-	_types.RegisterFunc[func(n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.interface{}]")
-	_types.RegisterClosure[func(), struct {
-		F  uintptr
-		X0 T
-	}]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.interface{}].func1")
 	_types.RegisterFunc[func(_fn0 ...int)]("github.com/stealthrocket/coroutine/compiler/testdata.varArgs")
 }

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3571,7 +3571,7 @@ func init() {
 			X1 int
 		}
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.(*Box).Closure.func2")
-	_types.RegisterFunc[func(_fn1 int) (_ func(T))]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure")
+	_types.RegisterFunc[func(_fn1 int) (_ func(int))]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure")
 	_types.RegisterClosure[func(_fn0 int), struct {
 		F  uintptr
 		D  uintptr

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -4,17 +4,15 @@ package testdata
 
 import (
 	coroutine "github.com/stealthrocket/coroutine"
-	time "time"
 	unsafe "unsafe"
+	time "time"
 )
 import _types "github.com/stealthrocket/coroutine/types"
 
 func SomeFunctionThatShouldExistInTheCompiledFile() {
 }
-
 //go:noinline
 func Identity(n int) { coroutine.Yield[int, any](n) }
-
 //go:noinline
 func SquareGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -50,7 +48,6 @@ func SquareGenerator(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func SquareGeneratorTwice(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -81,7 +78,6 @@ func SquareGeneratorTwice(_fn0 int) {
 		SquareGenerator(_f0.X0)
 	}
 }
-
 //go:noinline
 func SquareGeneratorTwiceLoop(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -117,7 +113,6 @@ func SquareGeneratorTwiceLoop(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func EvenSquareGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -165,7 +160,6 @@ func EvenSquareGenerator(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func NestedLoops(_fn0 int) (_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -247,7 +241,6 @@ func NestedLoops(_fn0 int) (_ int) {
 	}
 	panic("unreachable")
 }
-
 //go:noinline
 func FizzBuzzIfGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -308,7 +301,6 @@ func FizzBuzzIfGenerator(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func FizzBuzzSwitchGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -393,7 +385,6 @@ func FizzBuzzSwitchGenerator(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func Shadowing(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -736,7 +727,6 @@ func Shadowing(_ int) {
 		coroutine.Yield[int, any](_f0.X22)
 	}
 }
-
 //go:noinline
 func RangeSliceIndexGenerator(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -779,7 +769,6 @@ func RangeSliceIndexGenerator(_ int) {
 		}
 	}
 }
-
 //go:noinline
 func RangeArrayIndexValueGenerator(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -836,7 +825,6 @@ func RangeArrayIndexValueGenerator(_ int) {
 		}
 	}
 }
-
 //go:noinline
 func TypeSwitchingGenerator(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -911,7 +899,6 @@ func TypeSwitchingGenerator(_ int) {
 		}
 	}
 }
-
 //go:noinline
 func LoopBreakAndContinue(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1066,7 +1053,6 @@ func LoopBreakAndContinue(_ int) {
 		}
 	}
 }
-
 //go:noinline
 func RangeOverMaps(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1401,7 +1387,6 @@ func RangeOverMaps(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func Range(_fn0 int, _fn1 func(int)) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1440,15 +1425,13 @@ func Range(_fn0 int, _fn1 func(int)) {
 		}
 	}
 }
-
 //go:noinline
 func Double(n int) { coroutine.Yield[int, any](2 * n) }
-
 //go:noinline
 func RangeTriple(n int) {
-	Range(n, func(i int) { coroutine.Yield[int, any](3 * i) })
+	Range(n, func(i int) { coroutine.Yield[int, any](3 * i) },
+	)
 }
-
 //go:noinline
 func RangeTripleFuncValue(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1483,7 +1466,6 @@ func RangeTripleFuncValue(_fn0 int) {
 		Range(_f0.X0, _f0.X1)
 	}
 }
-
 //go:noinline
 func RangeReverseClosureCaptureByValue(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1533,7 +1515,6 @@ func RangeReverseClosureCaptureByValue(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func Range10ClosureCapturingValues() {
 	_c := coroutine.LoadContext[int, any]()
@@ -1640,7 +1621,6 @@ func Range10ClosureCapturingValues() {
 		}
 	}
 }
-
 //go:noinline
 func Range10ClosureCapturingPointers() {
 	_c := coroutine.LoadContext[int, any]()
@@ -1757,7 +1737,6 @@ func Range10ClosureCapturingPointers() {
 		}
 	}
 }
-
 //go:noinline
 func Range10ClosureHeterogenousCapture() {
 	_c := coroutine.LoadContext[int, any]()
@@ -1977,7 +1956,6 @@ func Range10ClosureHeterogenousCapture() {
 		}
 	}
 }
-
 //go:noinline
 func Range10Heterogenous() {
 	_c := coroutine.LoadContext[int, any]()
@@ -2089,7 +2067,6 @@ func Range10Heterogenous() {
 		}
 	}
 }
-
 //go:noinline
 func Select(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -2384,7 +2361,6 @@ func Select(_fn0 int) {
 		}
 	}
 }
-
 //go:noinline
 func YieldingExpressionDesugaring() {
 	_c := coroutine.LoadContext[int, any]()
@@ -2807,7 +2783,6 @@ func YieldingExpressionDesugaring() {
 		}
 	}
 }
-
 //go:noinline
 func a(_fn0 int) (_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -2839,7 +2814,6 @@ func a(_fn0 int) (_ int) {
 	}
 	panic("unreachable")
 }
-
 //go:noinline
 func b(_fn0 int) (_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -2871,7 +2845,6 @@ func b(_fn0 int) (_ int) {
 	}
 	panic("unreachable")
 }
-
 //go:noinline
 func YieldingDurations() {
 	_c := coroutine.LoadContext[int, any]()
@@ -2979,7 +2952,6 @@ func YieldingDurations() {
 		}
 	}
 }
-
 //go:noinline
 func YieldAndDeferAssign(_fn0 *int, _fn1, _fn2 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3024,7 +2996,6 @@ func YieldAndDeferAssign(_fn0 *int, _fn1, _fn2 int) {
 		coroutine.Yield[int, any](_f0.X1)
 	}
 }
-
 //go:noinline
 func RangeYieldAndDeferAssign(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3062,7 +3033,6 @@ func RangeYieldAndDeferAssign(_fn0 int) {
 }
 
 type MethodGeneratorState struct{ i int }
-
 //go:noinline
 func (_fn0 *MethodGeneratorState) MethodGenerator(_fn1 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3099,7 +3069,6 @@ func (_fn0 *MethodGeneratorState) MethodGenerator(_fn1 int) {
 		}
 	}
 }
-
 //go:noinline
 func VarArgs(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3139,7 +3108,6 @@ func VarArgs(_fn0 int) {
 		varArgs(_f0.X1...)
 	}
 }
-
 //go:noinline
 func varArgs(_fn0 ...int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3196,7 +3164,6 @@ func varArgs(_fn0 ...int) {
 		}
 	}
 }
-
 //go:noinline
 func ReturnNamedValue() (_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3236,26 +3203,21 @@ func ReturnNamedValue() (_fn0 int) {
 	}
 	panic("unreachable")
 }
-
 //go:noinline
 func IdentityGeneric[T any](n T) { coroutine.Yield[T, any](n) }
 
 type IdentityGenericStruct[T any] struct {
 	n T
 }
-
 //go:noinline
 func (i *IdentityGenericStruct[T]) Run() { coroutine.Yield[T, any](i.n) }
-
 //go:noinline
 func IdentityGenericInt(n int) { IdentityGeneric[int](n) }
-
 //go:noinline
 func IdentityGenericStructInt(n int) { (&IdentityGenericStruct[int]{n: n}).Run() }
-
 //go:noinline
 func IdentityGenericClosure[T any](_fn0 T) {
-	_c := coroutine.LoadContext[int, any]()
+	_c := coroutine.LoadContext[T, any]()
 	var _f0 *struct {
 		IP int
 		X0 T
@@ -3299,18 +3261,20 @@ func buildClosure[T any](n T) func() {
 		coroutine.Yield[T, any](n)
 	}
 }
-
 //go:noinline
 func IdentityGenericClosureInt(n int) { IdentityGenericClosure[int](n) }
 func init() {
+	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Run")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.EvenSquareGenerator")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.FizzBuzzIfGenerator")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.FizzBuzzSwitchGenerator")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Identity")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericClosureInt")
+	_types.RegisterFunc[func[T any](_fn0 T)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericClosure[go.shape.int]")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericInt")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericStructInt")
+	_types.RegisterFunc[func[T any](n T)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGeneric[go.shape.int]")
 	_types.RegisterFunc[func(_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.LoopBreakAndContinue")
 	_types.RegisterFunc[func(_fn1 int)]("github.com/stealthrocket/coroutine/compiler/testdata.MethodGenerator")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.NestedLoops")
@@ -3435,5 +3399,15 @@ func init() {
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.YieldingExpressionDesugaring")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.a")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.b")
+	_types.RegisterFunc[func[T any](n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int]")
+	_types.RegisterClosure[func(), struct {
+		F  uintptr
+		X0 T
+	}]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int].func1")
+	_types.RegisterFunc[func[T any](n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.interface{}]")
+	_types.RegisterClosure[func(), struct {
+		F  uintptr
+		X0 T
+	}]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.interface{}].func1")
 	_types.RegisterFunc[func(_fn0 ...int)]("github.com/stealthrocket/coroutine/compiler/testdata.varArgs")
 }

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3577,8 +3577,8 @@ func init() {
 		D  uintptr
 		X0 *struct {
 			IP int
-			X0 *IdentityGenericStruct[T]
-			X1 T
+			X0 *IdentityGenericStruct[int]
+			X1 int
 		}
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure.func2")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Run")

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3293,7 +3293,11 @@ func buildClosure[T any](n T) func() {
 //go:noinline
 func IdentityGenericClosureInt(n int) { IdentityGenericClosure[int](n) }
 
-type IdentityGenericStruct[T any] struct {
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+type IdentityGenericStruct[T integer] struct {
 	n T
 }
 
@@ -3301,10 +3305,13 @@ type IdentityGenericStruct[T any] struct {
 func (i *IdentityGenericStruct[T]) Run() { coroutine.Yield[T, any](i.n) }
 
 //go:noinline
-func (i *IdentityGenericStruct[T]) Closure(n T) func() {
-	return func() {
+func (i *IdentityGenericStruct[T]) Closure(n T) func(T) {
+	return func(x T) {
 		coroutine.Yield[T, any](i.n)
+		i.n++
 		coroutine.Yield[T, any](n)
+		n++
+		coroutine.Yield[T, any](x)
 	}
 }
 
@@ -3317,17 +3324,17 @@ func IdentityGenericStructClosureInt(_fn0 int) {
 	var _f0 *struct {
 		IP int
 		X0 int
-		X1 func()
+		X1 func(int)
 	} = coroutine.Push[struct {
 		IP int
 		X0 int
-		X1 func()
+		X1 func(int)
 	}](&_c.Stack)
 	if _f0.IP == 0 {
 		*_f0 = struct {
 			IP int
 			X0 int
-			X1 func()
+			X1 func(int)
 		}{X0: _fn0}
 	}
 	defer func() {
@@ -3341,16 +3348,16 @@ func IdentityGenericStructClosureInt(_fn0 int) {
 		_f0.IP = 2
 		fallthrough
 	case _f0.IP < 3:
-		_f0.X1()
+		_f0.X1(23)
 		_f0.IP = 3
 		fallthrough
 	case _f0.IP < 4:
-		_f0.X1()
+		_f0.X1(45)
 	}
 }
 func init() {
-	_types.RegisterFunc[func(n int) func()]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure")
-	_types.RegisterClosure[func(), struct {
+	_types.RegisterFunc[func(n int) func(T)]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure")
+	_types.RegisterClosure[func(x int), struct {
 		F  uintptr
 		D  uintptr
 		X0 int

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3360,7 +3360,8 @@ func init() {
 	_types.RegisterClosure[func(x int), struct {
 		F  uintptr
 		D  uintptr
-		X0 int
+		X0 *IdentityGenericStruct[T]
+		X1 int
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Closure.func1")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.(*IdentityGenericStruct[go.shape.int]).Run")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Double")

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -4,15 +4,17 @@ package testdata
 
 import (
 	coroutine "github.com/stealthrocket/coroutine"
-	unsafe "unsafe"
 	time "time"
+	unsafe "unsafe"
 )
 import _types "github.com/stealthrocket/coroutine/types"
 
 func SomeFunctionThatShouldExistInTheCompiledFile() {
 }
+
 //go:noinline
 func Identity(n int) { coroutine.Yield[int, any](n) }
+
 //go:noinline
 func SquareGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -48,6 +50,7 @@ func SquareGenerator(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func SquareGeneratorTwice(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -78,6 +81,7 @@ func SquareGeneratorTwice(_fn0 int) {
 		SquareGenerator(_f0.X0)
 	}
 }
+
 //go:noinline
 func SquareGeneratorTwiceLoop(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -113,6 +117,7 @@ func SquareGeneratorTwiceLoop(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func EvenSquareGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -160,6 +165,7 @@ func EvenSquareGenerator(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func NestedLoops(_fn0 int) (_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -241,6 +247,7 @@ func NestedLoops(_fn0 int) (_ int) {
 	}
 	panic("unreachable")
 }
+
 //go:noinline
 func FizzBuzzIfGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -301,6 +308,7 @@ func FizzBuzzIfGenerator(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func FizzBuzzSwitchGenerator(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -385,6 +393,7 @@ func FizzBuzzSwitchGenerator(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func Shadowing(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -727,6 +736,7 @@ func Shadowing(_ int) {
 		coroutine.Yield[int, any](_f0.X22)
 	}
 }
+
 //go:noinline
 func RangeSliceIndexGenerator(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -769,6 +779,7 @@ func RangeSliceIndexGenerator(_ int) {
 		}
 	}
 }
+
 //go:noinline
 func RangeArrayIndexValueGenerator(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -825,6 +836,7 @@ func RangeArrayIndexValueGenerator(_ int) {
 		}
 	}
 }
+
 //go:noinline
 func TypeSwitchingGenerator(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -899,6 +911,7 @@ func TypeSwitchingGenerator(_ int) {
 		}
 	}
 }
+
 //go:noinline
 func LoopBreakAndContinue(_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1053,6 +1066,7 @@ func LoopBreakAndContinue(_ int) {
 		}
 	}
 }
+
 //go:noinline
 func RangeOverMaps(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1387,6 +1401,7 @@ func RangeOverMaps(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func Range(_fn0 int, _fn1 func(int)) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1425,13 +1440,15 @@ func Range(_fn0 int, _fn1 func(int)) {
 		}
 	}
 }
+
 //go:noinline
 func Double(n int) { coroutine.Yield[int, any](2 * n) }
+
 //go:noinline
 func RangeTriple(n int) {
-	Range(n, func(i int) { coroutine.Yield[int, any](3 * i) },
-	)
+	Range(n, func(i int) { coroutine.Yield[int, any](3 * i) })
 }
+
 //go:noinline
 func RangeTripleFuncValue(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1466,6 +1483,7 @@ func RangeTripleFuncValue(_fn0 int) {
 		Range(_f0.X0, _f0.X1)
 	}
 }
+
 //go:noinline
 func RangeReverseClosureCaptureByValue(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -1515,6 +1533,7 @@ func RangeReverseClosureCaptureByValue(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func Range10ClosureCapturingValues() {
 	_c := coroutine.LoadContext[int, any]()
@@ -1621,6 +1640,7 @@ func Range10ClosureCapturingValues() {
 		}
 	}
 }
+
 //go:noinline
 func Range10ClosureCapturingPointers() {
 	_c := coroutine.LoadContext[int, any]()
@@ -1737,6 +1757,7 @@ func Range10ClosureCapturingPointers() {
 		}
 	}
 }
+
 //go:noinline
 func Range10ClosureHeterogenousCapture() {
 	_c := coroutine.LoadContext[int, any]()
@@ -1956,6 +1977,7 @@ func Range10ClosureHeterogenousCapture() {
 		}
 	}
 }
+
 //go:noinline
 func Range10Heterogenous() {
 	_c := coroutine.LoadContext[int, any]()
@@ -2067,6 +2089,7 @@ func Range10Heterogenous() {
 		}
 	}
 }
+
 //go:noinline
 func Select(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -2361,6 +2384,7 @@ func Select(_fn0 int) {
 		}
 	}
 }
+
 //go:noinline
 func YieldingExpressionDesugaring() {
 	_c := coroutine.LoadContext[int, any]()
@@ -2783,6 +2807,7 @@ func YieldingExpressionDesugaring() {
 		}
 	}
 }
+
 //go:noinline
 func a(_fn0 int) (_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -2814,6 +2839,7 @@ func a(_fn0 int) (_ int) {
 	}
 	panic("unreachable")
 }
+
 //go:noinline
 func b(_fn0 int) (_ int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -2845,6 +2871,7 @@ func b(_fn0 int) (_ int) {
 	}
 	panic("unreachable")
 }
+
 //go:noinline
 func YieldingDurations() {
 	_c := coroutine.LoadContext[int, any]()
@@ -2952,6 +2979,7 @@ func YieldingDurations() {
 		}
 	}
 }
+
 //go:noinline
 func YieldAndDeferAssign(_fn0 *int, _fn1, _fn2 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -2996,6 +3024,7 @@ func YieldAndDeferAssign(_fn0 *int, _fn1, _fn2 int) {
 		coroutine.Yield[int, any](_f0.X1)
 	}
 }
+
 //go:noinline
 func RangeYieldAndDeferAssign(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3033,6 +3062,7 @@ func RangeYieldAndDeferAssign(_fn0 int) {
 }
 
 type MethodGeneratorState struct{ i int }
+
 //go:noinline
 func (_fn0 *MethodGeneratorState) MethodGenerator(_fn1 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3069,6 +3099,7 @@ func (_fn0 *MethodGeneratorState) MethodGenerator(_fn1 int) {
 		}
 	}
 }
+
 //go:noinline
 func VarArgs(_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3108,6 +3139,7 @@ func VarArgs(_fn0 int) {
 		varArgs(_f0.X1...)
 	}
 }
+
 //go:noinline
 func varArgs(_fn0 ...int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3164,6 +3196,7 @@ func varArgs(_fn0 ...int) {
 		}
 	}
 }
+
 //go:noinline
 func ReturnNamedValue() (_fn0 int) {
 	_c := coroutine.LoadContext[int, any]()
@@ -3203,21 +3236,26 @@ func ReturnNamedValue() (_fn0 int) {
 	}
 	panic("unreachable")
 }
+
 //go:noinline
-func IdentityGeneric[T any](n T) { coroutine.Yield[T, any](n) }
+func IdentityGeneric(n int) { coroutine.Yield[T, any](n) }
 
 type IdentityGenericStruct[T any] struct {
 	n T
 }
+
 //go:noinline
 func (i *IdentityGenericStruct[T]) Run() { coroutine.Yield[T, any](i.n) }
+
 //go:noinline
 func IdentityGenericInt(n int) { IdentityGeneric[int](n) }
+
 //go:noinline
 func IdentityGenericStructInt(n int) { (&IdentityGenericStruct[int]{n: n}).Run() }
+
 //go:noinline
-func IdentityGenericClosure[T any](_fn0 T) {
-	_c := coroutine.LoadContext[T, any]()
+func IdentityGenericClosure(_fn0 int) {
+	_c := coroutine.LoadContext[int, any]()
 	var _f0 *struct {
 		IP int
 		X0 T
@@ -3256,11 +3294,12 @@ func IdentityGenericClosure[T any](_fn0 T) {
 // TODO: add this go:noinline directive automatically
 //
 //go:noinline
-func buildClosure[T any](n T) func() {
+func buildClosure(n T) func() {
 	return func() {
 		coroutine.Yield[T, any](n)
 	}
 }
+
 //go:noinline
 func IdentityGenericClosureInt(n int) { IdentityGenericClosure[int](n) }
 func init() {
@@ -3271,10 +3310,10 @@ func init() {
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.FizzBuzzSwitchGenerator")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.Identity")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericClosureInt")
-	_types.RegisterFunc[func[T any](_fn0 T)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericClosure[go.shape.int]")
+	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericClosure[go.shape.int]")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericInt")
 	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGenericStructInt")
-	_types.RegisterFunc[func[T any](n T)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGeneric[go.shape.int]")
+	_types.RegisterFunc[func(n int)]("github.com/stealthrocket/coroutine/compiler/testdata.IdentityGeneric[go.shape.int]")
 	_types.RegisterFunc[func(_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.LoopBreakAndContinue")
 	_types.RegisterFunc[func(_fn1 int)]("github.com/stealthrocket/coroutine/compiler/testdata.MethodGenerator")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.NestedLoops")
@@ -3399,12 +3438,12 @@ func init() {
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.YieldingExpressionDesugaring")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.a")
 	_types.RegisterFunc[func(_fn0 int) (_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.b")
-	_types.RegisterFunc[func[T any](n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int]")
+	_types.RegisterFunc[func(n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int]")
 	_types.RegisterClosure[func(), struct {
 		F  uintptr
-		X0 T
+		X0 int
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.int].func1")
-	_types.RegisterFunc[func[T any](n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.interface{}]")
+	_types.RegisterFunc[func(n T) func()]("github.com/stealthrocket/coroutine/compiler/testdata.buildClosure[go.shape.interface{}]")
 	_types.RegisterClosure[func(), struct {
 		F  uintptr
 		X0 T

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -53,7 +53,7 @@ func typeExpr(p *packages.Package, typ types.Type, typeArg func(*types.TypeParam
 			return ast.NewIdent("any")
 		}
 	case *types.Signature:
-		return newFuncType(p, t)
+		return newFuncType(p, t, typeArg)
 	case *types.Named:
 		obj := t.Obj()
 		name := ast.NewIdent(obj.Name())
@@ -108,24 +108,24 @@ func typeExpr(p *packages.Package, typ types.Type, typeArg func(*types.TypeParam
 	panic(fmt.Sprintf("not implemented: %T", typ))
 }
 
-func newFuncType(p *packages.Package, signature *types.Signature) *ast.FuncType {
+func newFuncType(p *packages.Package, signature *types.Signature, typeArg func(*types.TypeParam) types.Type) *ast.FuncType {
 	return &ast.FuncType{
-		Params:  newFieldList(p, signature.Params()),
-		Results: newFieldList(p, signature.Results()),
+		Params:  newFieldList(p, signature.Params(), typeArg),
+		Results: newFieldList(p, signature.Results(), typeArg),
 	}
 }
 
-func newFieldList(p *packages.Package, tuple *types.Tuple) *ast.FieldList {
+func newFieldList(p *packages.Package, tuple *types.Tuple, typeArg func(*types.TypeParam) types.Type) *ast.FieldList {
 	return &ast.FieldList{
-		List: newFields(p, tuple),
+		List: newFields(p, tuple, typeArg),
 	}
 }
 
-func newFields(p *packages.Package, tuple *types.Tuple) []*ast.Field {
+func newFields(p *packages.Package, tuple *types.Tuple, typeArg func(*types.TypeParam) types.Type) []*ast.Field {
 	fields := make([]*ast.Field, tuple.Len())
 	for i := range fields {
 		fields[i] = &ast.Field{
-			Type: typeExpr(p, tuple.At(i).Type(), nil),
+			Type: typeExpr(p, tuple.At(i).Type(), typeArg),
 		}
 	}
 	return fields


### PR DESCRIPTION
This PR adds initial support for generics.

The guide at https://github.com/golang/proposal/blob/master/design/generics-implementation-dictionaries-go1.18.md has been helpful in understanding how the Go compiler implements generics (via a combination of stenciling and dictionaries).

Fixes #123.