### PR TITLE
only list files

### DIFF
--- a/compiler/cmd/coroc/main.go
+++ b/compiler/cmd/coroc/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"runtime/debug"
 
@@ -17,8 +19,19 @@ USAGE:
 
 OPTIONS:
   -h, --help      Show this help information
+  -l, --list      List all files that would be compiled
   -v, --version   Show the compiler version
 `
+
+var (
+	showVersion   bool
+	onlyListFiles bool
+)
+
+func boolFlag(ptr *bool, short, long string) {
+	flag.BoolVar(ptr, short, false, "")
+	flag.BoolVar(ptr, long, false, "")
+}
 
 func main() {
 	if err := run(); err != nil {
@@ -30,10 +43,8 @@ func main() {
 func run() error {
 	flag.Usage = func() { println(usage[1:]) }
 
-	var showVersion bool
-	flag.BoolVar(&showVersion, "v", false, "")
-	flag.BoolVar(&showVersion, "version", false, "")
-
+	boolFlag(&showVersion, "v", "version")
+	boolFlag(&onlyListFiles, "l", "list")
 	flag.Parse()
 
 	if showVersion {
@@ -55,7 +66,13 @@ func run() error {
 		}
 	}
 
-	return compiler.Compile(path)
+	if onlyListFiles {
+		log.SetOutput(io.Discard)
+	}
+
+	return compiler.Compile(path,
+		compiler.OnlyListFiles(onlyListFiles),
+	)
 }
 
 func version() (version string) {

--- a/compiler/options.go
+++ b/compiler/options.go
@@ -1,0 +1,10 @@
+package compiler
+
+// Option configures the compiler.
+type Option func(*compiler)
+
+func OnlyListFiles(enabled bool) Option {
+	return func(c *compiler) {
+		c.onlyListFiles = enabled
+	}
+}


### PR DESCRIPTION
This PR adds a `--list` option to `coroc` to allow only listing files for which it would generate a durable version.

It worked, but in the current form most of the compilation time is spent in phases before we get to the point where we know which files will change, so it isn't very useful to integrate with a tool like `make` yet (until we make the compiler a bit faster).