### PR TITLE
coroc: skip synthetic functions

### DIFF
--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -199,6 +199,9 @@ func (c *compiler) compile(path string) error {
 			}
 		}
 		if pkg == nil {
+			if fn.Synthetic != "" {
+				continue
+			}
 			return fmt.Errorf("unsupported yield function %s (Pkg is nil)", fn)
 		}
 
@@ -320,7 +323,7 @@ func (c *compiler) compilePackage(p *packages.Package, colors functionColors) er
 		case *ast.FuncDecl:
 		case *ast.FuncLit:
 		default:
-			return fmt.Errorf("unsupported yield function %s (Syntax is %T, not *ast.FuncDecl or *ast.FuncLit)", fn, decl)
+			continue
 		}
 		colorsByFunc[decl] = color
 	}


### PR DESCRIPTION
Synthetic functions (wrappers/bounds/thunks) encountered during analysis were causing issues, since we attempt to partition functions into packages and these synthetic functions do not have a package. 