### PR TITLE
coroc: support range over int (Go 1.22)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - run: go mod download
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.56.1
           args: --timeout 5m
 
   test:

--- a/compiler/coroutine_test.go
+++ b/compiler/coroutine_test.go
@@ -249,6 +249,12 @@ func TestCoroutineYield(t *testing.T) {
 			coro:   func() { IndirectClosure(1) },
 			yields: []int{-1, 1, 2, 3},
 		},
+
+		{
+			name:   "range over int",
+			coro:   func() { RangeOverInt(3) },
+			yields: []int{0, 1, 2},
+		},
 	}
 
 	// This emulates the installation of function type information by the

--- a/compiler/desugar_test.go
+++ b/compiler/desugar_test.go
@@ -1146,6 +1146,63 @@ defer func() {
 }
 `,
 		},
+		{
+			name: "for range over int",
+			body: "for range n { foo }",
+			info: func(stmts []ast.Stmt, info *types.Info) {
+				n := stmts[0].(*ast.RangeStmt).X
+				info.Types[n] = types.TypeAndValue{Type: intType}
+			},
+			expect: `
+{
+	_v0 := n
+	{
+		_v1 := 0
+		for ; _v1 < _v0; _v1++ {
+			foo
+		}
+	}
+}
+`,
+		},
+		{
+			name: "for range over int, with underscore index",
+			body: "for _ := range n { foo }",
+			info: func(stmts []ast.Stmt, info *types.Info) {
+				n := stmts[0].(*ast.RangeStmt).X
+				info.Types[n] = types.TypeAndValue{Type: intType}
+			},
+			expect: `
+{
+	_v0 := n
+	{
+		_v1 := 0
+		for ; _v1 < _v0; _v1++ {
+			foo
+		}
+	}
+}
+`,
+		},
+		{
+			name: "for range over int, with index",
+			body: "for i := range n { foo }",
+			info: func(stmts []ast.Stmt, info *types.Info) {
+				n := stmts[0].(*ast.RangeStmt).X
+				info.Types[n] = types.TypeAndValue{Type: intType}
+			},
+			expect: `
+{
+	_v0 := n
+	{
+		i := 0
+		for ; i < _v0; i++ {
+			foo
+		}
+	}
+}
+`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			expr, err := parser.ParseExpr("func() {\n" + test.body + "\n}()")

--- a/compiler/testdata/coroutine.go
+++ b/compiler/testdata/coroutine.go
@@ -656,3 +656,9 @@ func indirectClosure(m interface{ YieldAndInc() }) func() {
 		m.YieldAndInc()
 	}
 }
+
+func RangeOverInt(n int) {
+	for i := range n {
+		coroutine.Yield[int, any](i)
+	}
+}

--- a/compiler/testdata/coroutine_durable.go
+++ b/compiler/testdata/coroutine_durable.go
@@ -3634,6 +3634,53 @@ func indirectClosure(_fn0 interface{ YieldAndInc() }) (_ func()) {
 	}
 	panic("unreachable")
 }
+
+//go:noinline
+func RangeOverInt(_fn0 int) {
+	_c := coroutine.LoadContext[int, any]()
+	var _f0 *struct {
+		IP int
+		X0 int
+		X1 int
+		X2 int
+	} = coroutine.Push[struct {
+		IP int
+		X0 int
+		X1 int
+		X2 int
+	}](&_c.Stack)
+	if _f0.IP == 0 {
+		*_f0 = struct {
+			IP int
+			X0 int
+			X1 int
+			X2 int
+		}{X0: _fn0}
+	}
+	defer func() {
+		if !_c.Unwinding() {
+			coroutine.Pop(&_c.Stack)
+		}
+	}()
+	switch {
+	case _f0.IP < 2:
+		_f0.X1 = _f0.X0
+		_f0.IP = 2
+		fallthrough
+	case _f0.IP < 4:
+		switch {
+		case _f0.IP < 3:
+			_f0.X2 = 0
+			_f0.IP = 3
+			fallthrough
+		case _f0.IP < 4:
+			for ; _f0.X2 < _f0.X1; _f0.X2, _f0.IP = _f0.X2+1, 3 {
+
+				coroutine.Yield[int, any](_f0.X2)
+			}
+		}
+	}
+}
 func init() {
 	_types.RegisterFunc[func(_fn1 int) (_ func(int))]("github.com/stealthrocket/coroutine/compiler/testdata.(*Box).Closure")
 	_types.RegisterClosure[func(_fn0 int), struct {
@@ -3741,6 +3788,7 @@ func init() {
 	}]("github.com/stealthrocket/coroutine/compiler/testdata.Range10ClosureHeterogenousCapture.func3")
 	_types.RegisterFunc[func()]("github.com/stealthrocket/coroutine/compiler/testdata.Range10Heterogenous")
 	_types.RegisterFunc[func(_ int)]("github.com/stealthrocket/coroutine/compiler/testdata.RangeArrayIndexValueGenerator")
+	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.RangeOverInt")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.RangeOverMaps")
 	_types.RegisterFunc[func(_fn0 int)]("github.com/stealthrocket/coroutine/compiler/testdata.RangeReverseClosureCaptureByValue")
 	_types.RegisterClosure[func(), struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stealthrocket/coroutine
 
-go 1.22
+go 1.22.0
 
 require (
 	golang.org/x/sync v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stealthrocket/coroutine
 
-go 1.21.0
+go 1.22
 
 require (
 	golang.org/x/sync v0.5.0


### PR DESCRIPTION
This PR updates coroc to desugar range-over-int loops, to be introduced in [Go 1.22](https://tip.golang.org/doc/go1.22) (~Feb 2024).

cc #110